### PR TITLE
[Feature] Show copilot usage as 'used' instead of 'remaining' (#13)

### DIFF
--- a/.config/nvim/README.md
+++ b/.config/nvim/README.md
@@ -56,20 +56,39 @@ nvim
 
 ## Android Development
 
-See [ANDROID_DEV_SETUP.md](ANDROID_DEV_SETUP.md) for detailed setup instructions.
+This config provides full IDE support for Android/Kotlin development.
+
+### What's Included
+
+- **Kotlin & Java LSP** — autocomplete, goto definition, hover docs, refactoring
+- **Auto-formatting** — ktlint for Kotlin, google-java-format for Java (runs on save)
+- **XML support** — syntax highlighting for Android layouts
+- **Debugger** — Kotlin debugger with attach-to-process (port 5005)
+- **Statusline** — shows "Android" or "Gradle" indicator when in a project
+- **SDK detection** — auto-detects SDK from `ANDROID_SDK_ROOT` or common paths (`~/Library/Android/sdk`, `~/Android/Sdk`)
 
 ### Quick Start
 
 1. Open any `.kt` or `.java` file in an Android project
 2. LSP will auto-start and provide IDE features
 3. Use `:Mason` to install missing tools if needed
+4. Run `:AndroidInfo` to check SDK path, JVM target, and project status
 
 ### Environment Variables
 
-Set in `~/.zsh-config/nvim-config.sh`:
+- `ANDROID_SDK_ROOT` — Android SDK path (auto-detected if not set)
+- `GRADLE_JVM_TARGET` — JVM target version (auto-detected from project)
+- `GRADLE_CACHE` — enable/disable Gradle caching (default: `true`)
 
-- `ANDROID_SDK_ROOT` — Android SDK path
-- `GRADLE_JVM_TARGET` — JVM target (auto-detected from project)
+### Optional Extras
+
+The file `lua/plugins/android-extras.lua` contains disabled-by-default plugins for:
+
+- **Full Android IDE** (`android-nvim-plugin`) — `:AndroidBuild`, `:AndroidRun`, `:AndroidLogcat`, `:AndroidDevices`, `:AndroidEmulator`
+- **Terminal ADB shortcuts** — `<leader>ad` (devices), `<leader>al` (logcat), `<leader>ai` (install APK)
+- **Gradle task runner** — `<leader>gb` (build), `<leader>gt` (test), `<leader>gc` (clean), `<leader>gr` (custom task)
+
+Uncomment the sections you want in that file to enable them.
 
 ## Troubleshooting
 

--- a/.config/opencode/README.md
+++ b/.config/opencode/README.md
@@ -10,7 +10,11 @@ Sidebar widget showing GitHub Copilot premium request usage.
 
 - Session usage tracking (user prompts × model multiplier)
 - Monthly quota from GitHub API (paid and free plans)
-- Progress bar with color coding (green/yellow/red)
+- Displays percentage **used** with progress bar (matching GitHub's UI)
+- Color coding based on usage level:
+  - Green: ≤75% used
+  - Yellow: 75–90% used
+  - Red: >90% used (or over quota)
 - Auto-refresh every 5 minutes
 
 **Files:** `plugins/copilot-usage.tsx`, `plugins/copilot-usage.config.json`, `plugins/tui.json`

--- a/.config/opencode/plugins/copilot-usage.tsx
+++ b/.config/opencode/plugins/copilot-usage.tsx
@@ -448,13 +448,6 @@ function CopilotUsageSidebar(props: { api: TuiPluginApi; session_id: string }) {
     return (used / quota.entitlement) * 100
   })
 
-  const remainingPercentage = createMemo(() => {
-    const quota = quotaInfo()
-    if (!quota) return 0
-    if (quota.unlimited) return 100
-    return quota.percentRemaining
-  })
-
   const usageColor = createMemo(() => getUsageColor(usagePercentage()))
 
   const isCopilot = createMemo(() => {
@@ -482,8 +475,8 @@ function CopilotUsageSidebar(props: { api: TuiPluginApi; session_id: string }) {
             <text fg="#22c55e">Unlimited</text>
           ) : quotaInfo() ? (
             <box flexDirection="column" gap={0}>
-              <text fg={usageColor()}>{remainingPercentage().toFixed(1)}% remaining</text>
-              <text fg={usageColor()}>{buildProgressBar(100 - remainingPercentage())}</text>
+              <text fg={usageColor()}>{usagePercentage().toFixed(1)}% used</text>
+              <text fg={usageColor()}>{buildProgressBar(usagePercentage())}</text>
             </box>
           ) : quotaLoading() ? (
             <text fg="#888888">Loading...</text>

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ This config provides full IDE support for Android development with Neovim:
 1. Open any `.kt` or `.java` file in an Android project
 2. LSP will auto-start and provide IDE features
 3. Use `:Mason` to install missing tools if needed
-4. See [ANDROID_DEV_SETUP.md](.config/nvim/ANDROID_DEV_SETUP.md) for detailed configuration
+4. Run `:AndroidInfo` to check SDK and project configuration
 
 **Optional Features:**
 The file `lua/plugins/android-extras.lua` contains optional plugins for:


### PR DESCRIPTION
## Summary
- Changed copilot-usage sidebar from showing "x% remaining" to "x% used" (matching GitHub's UI)
- Progress bar now uses `usagePercentage()` directly instead of `100 - remainingPercentage()`
- Expanded opencode README with accurate color thresholds
- Removed dead `remainingPercentage` memo function
- Updated nvim README with expanded Android development docs
- Updated root README quick start step 4

## Changes
- `.config/opencode/plugins/copilot-usage.tsx` — display logic + dead code removal
- `.config/opencode/README.md` — expanded plugin description with color thresholds
- `.config/nvim/README.md` — expanded Android development section
- `README.md` — updated Android quick start step

Closes #13