### PR TITLE
Added hard cap to /usage navigation based on earliest database records

### DIFF
--- a/.config/opencode/README.md
+++ b/.config/opencode/README.md
@@ -25,7 +25,8 @@ Sidebar widget + `/usage` slash command (`Ctrl+Shift+U`) showing token usage and
 - **opencode-go** — rolling (5h), weekly, and monthly quota scraped from opencode.ai
 
 **`/usage` command:** Monthly token breakdown per model (top 10) with progress bars, queried from OpenCode's SQLite database.
-- **Month navigation** — `←` `→` arrows to browse past months (cached instantly)
+- **Month navigation** — `←` `→` arrows to browse past months, hard-capped at earliest database record. Dynamic arrow hints show available directions.
+- **Today** — `t` to jump back to the current month
 - **Reload** — `r` to refresh current month data
 - **Scroll** — `↑` `↓` (or `j` `k`) with overflow hints (`▲` / `▼`)
 - **Persistent cache** — past months saved to disk for instant recall

--- a/.config/opencode/plugins/model-usage/command.tsx
+++ b/.config/opencode/plugins/model-usage/command.tsx
@@ -6,7 +6,7 @@ import { homedir } from "node:os"
 import { onMount, onCleanup, createSignal } from "solid-js"
 import { getMonthInfo, isCurrentMonth, fmt, fmtCost, buildBar, randomReloadMessage } from "./helpers"
 import type { UsageData } from "./types"
-import { queryUsage } from "./db"
+import { queryUsage, getEarliestUsageDate } from "./db"
 
 // ─── Persistent multi-month cache ─────────────────────────────────────────
 const CACHE_DIR = `${homedir()}/.config/opencode/plugins/model-usage`
@@ -95,6 +95,21 @@ export function registerUsageCommand(api: TuiPluginApi) {
               )
             })
             return
+          }
+
+          // ── Determine earliest month with data ──────────────────────────
+          let minMonthOffset = 0
+          {
+            const earliestMs = getEarliestUsageDate(dbPath)
+            if (earliestMs != null) {
+              const earliestDate = new Date(earliestMs)
+              const earliestYear = earliestDate.getUTCFullYear()
+              const earliestMonth = earliestDate.getUTCMonth()
+              const currentYear = now.getUTCFullYear()
+              const currentMonth = now.getUTCMonth()
+              const monthsBack = (currentYear * 12 + currentMonth) - (earliestYear * 12 + earliestMonth)
+              minMonthOffset = -monthsBack
+            }
           }
 
           // ── State ────────────────────────────────────────────────────────
@@ -187,6 +202,7 @@ export function registerUsageCommand(api: TuiPluginApi) {
 
           function handleKey(key: string) {
             if (key === "left" || key === "h") {
+              if (monthOffset() <= minMonthOffset) return true  // hard cap: no older months available
               setMonthOffset(p => p - 1)
               setIsScrolled(false)
               setIsAtBottom(false)
@@ -206,6 +222,14 @@ export function registerUsageCommand(api: TuiPluginApi) {
               if (isCurrentMonth(startMs)) {
                 loadMonth(true)
               }
+              return true
+            }
+            if (key === "t") {
+              if (monthOffset() === 0) return true  // already at current month
+              setMonthOffset(0)
+              setIsScrolled(false)
+              setIsAtBottom(false)
+              setTimeout(() => loadMonth(), 10)
               return true
             }
             if (key === "up") {
@@ -234,6 +258,17 @@ export function registerUsageCommand(api: TuiPluginApi) {
           // ── Reactive dialog ─────────────────────────────────────────────
           api.ui.dialog.replace(() => {
             const { label } = computeMonth()
+            const offset = monthOffset()
+            let arrows: string
+            if (minMonthOffset === 0) {
+              arrows = ""                    // Case 4: only month available
+            } else if (offset >= 0) {
+              arrows = " ←"                  // Case 1: at current month, can only go older
+            } else if (offset <= minMonthOffset) {
+              arrows = " →"                  // Case 3: at oldest month, can only go newer
+            } else {
+              arrows = " ← →"                // Case 2: middle month, both directions
+            }
             onMount(() => {
               api.ui.dialog.setSize("large")
               // Register dialog key layer
@@ -244,6 +279,7 @@ export function registerUsageCommand(api: TuiPluginApi) {
                   { key: "right", cmd: "usage.navRight", desc: "Next month" },
                   { key: "l",     cmd: "usage.navRight", desc: "Next month" },
                   { key: "r",     cmd: "usage.reload",   desc: "Reload" },
+                  { key: "t",     cmd: "usage.today",   desc: "Today" },
                   { key: "up",   cmd: "usage.scrollUp",   desc: "Scroll up" },
                   { key: "k",    cmd: "usage.scrollUp",   desc: "Scroll up" },
                   { key: "down", cmd: "usage.scrollDown", desc: "Scroll down" },
@@ -253,6 +289,7 @@ export function registerUsageCommand(api: TuiPluginApi) {
                   { name: "usage.navLeft",   title: "Previous Month", async run() { handleKey("left") } },
                   { name: "usage.navRight",  title: "Next Month",     async run() { handleKey("right") } },
                   { name: "usage.reload",    title: "Reload Usage",   async run() { handleKey("r") } },
+                  { name: "usage.today",    title: "Today",        async run() { handleKey("t") } },
                   { name: "usage.scrollUp",   title: "Scroll Up",   async run() { handleKey("up") } },
                   { name: "usage.scrollDown", title: "Scroll Down", async run() { handleKey("down") } },
                 ],
@@ -261,12 +298,17 @@ export function registerUsageCommand(api: TuiPluginApi) {
               loadMonth()
               // Background: prefetch past months so navigation is instant
               setTimeout(() => {
+                // Compute earliest month timestamp from the data cap
+                const minMonthYear = now.getUTCFullYear() + Math.floor((now.getUTCMonth() + minMonthOffset) / 12)
+                const minMonthMonth = ((now.getUTCMonth() + minMonthOffset) % 12 + 12) % 12
+                const minPrefetchMs = Date.UTC(minMonthYear, minMonthMonth, 1)
+
                 let m = now.getUTCMonth() - 1
                 let y = now.getUTCFullYear()
                 while (true) {
                   if (m < 0) { m = 11; y-- }
-                  if (y < 2024) break
                   const startMs = Date.UTC(y, m, 1)
+                  if (startMs < minPrefetchMs) break
                   if (getCached(startMs)) { m--; continue }
                   const endMs = Date.UTC(y, m + 1, 1)
                   const result = queryUsage(dbPath, startMs, endMs)
@@ -289,7 +331,7 @@ export function registerUsageCommand(api: TuiPluginApi) {
                 <box flexDirection="row" justifyContent="space-between">
                   <box flexDirection="row" gap={1}>
                     <text fg={fg}><b>Usage</b></text>
-                    <text fg={muted}>{label} ← →</text>
+                    <text fg={muted}>{label}{arrows}</text>
                   </box>
                   <text fg={muted}>esc</text>
                 </box>
@@ -353,7 +395,7 @@ export function registerUsageCommand(api: TuiPluginApi) {
                 })()}
                 {reloading() && <text fg={muted}>{reloadMsg()}</text>}
                 {hasLoadedOnce() && (
-                  <text fg={muted}>← → month  ·  r reload  ·  ↑↓ scroll</text>
+                  <text fg={muted}>t today  ·  ← → month  ·  r reload  ·  ↑↓ scroll</text>
                 )}
               </box>
             )

--- a/.config/opencode/plugins/model-usage/db.ts
+++ b/.config/opencode/plugins/model-usage/db.ts
@@ -62,3 +62,24 @@ export function queryUsage(dbPath: string, startMs: number, endMs: number): Usag
     }
   }
 }
+
+export function getEarliestUsageDate(dbPath: string): number | null {
+  let db: Database | null = null
+  try {
+    db = new Database(dbPath, { readonly: true })
+    const row = db
+      .query(
+        `SELECT MIN(time_created) AS earliest
+         FROM message
+         WHERE json_extract(data, '$.role') = 'assistant'`
+      )
+      .get() as { earliest: number | null } | undefined
+    db.close()
+    db = null
+    return row?.earliest ?? null
+  } catch {
+    return null
+  } finally {
+    try { db?.close() } catch { /* ignore */ }
+  }
+}


### PR DESCRIPTION
### Changelist Summary
Capped `/usage` command navigation at the earliest month with data in the database, added dynamic directional arrow indicators, and added `t` shortcut to jump to the current month.

### Description
Previously, pressing `←` / `h` in the `/usage` dialog could navigate indefinitely into past months with no lower bound. This change:

- **`db.ts`**: Added `getEarliestUsageDate()` that queries `MIN(time_created)` for assistant messages.
- **Hard cap**: On dialog open, computes the earliest allowed `monthOffset` and blocks left navigation past that month.
- **Dynamic arrows**: The header now shows context-aware navigation hints (`←`, `← →`, `→`, or none) based on current position and available data.
- **`t` shortcut**: Press `t` to jump back to the current month from any historical view.
- **Prefetch cleanup**: Replaced the hardcoded `y < 2024` prefetch bound with the dynamic data-driven boundary.

> ⚠️ **Auto-generated description.** This PR was generated by an AI agent and may contain inaccuracies or be incomplete. Please review and correct it before merging.