### PR TITLE
Fixed tool label alignment in analyze tab and peak input token display in sidebar

### DIFF
--- a/.config/opencode/plugins/model-usage/analyze.test.ts
+++ b/.config/opencode/plugins/model-usage/analyze.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test"
 import { estimateTokens, rawPromptTokens, scaleEntries } from "./helpers/tokens"
 import { splitSystemFragments } from "./helpers/fragments"
 import { loadBaseline } from "./db"
+import { truncateLabel } from "./helpers/format"
 
 // ─── estimateTokens ───────────────────────────────────────────────────────────
 
@@ -177,5 +178,36 @@ describe("loadBaseline", () => {
     } finally {
       try { require("node:fs").unlinkSync(tmp) } catch { /* ignore */ }
     }
+  })
+})
+
+// ─── truncateLabel ─────────────────────────────────────────────────────────────
+
+describe("truncateLabel", () => {
+  it("pads short labels to maxLen", () => {
+    expect(truncateLabel("hi", 26)).toBe("hi" + " ".repeat(24))
+  })
+
+  it("returns exact-length label unchanged (no truncation)", () => {
+    const label = "a".repeat(26)
+    expect(truncateLabel(label, 26)).toBe(label)
+  })
+
+  it("truncates overflow labels with ellipsis", () => {
+    const label = "very_long_tool_name_that_overflows"
+    expect(label.length).toBeGreaterThan(26)
+    const result = truncateLabel(label, 26)
+    expect(result).toBe("very_long_tool_name_that_…")
+    expect(result.length).toBe(26)
+  })
+
+  it("uses default maxLen of 26", () => {
+    const result = truncateLabel("very_long_tool_name_that_overflows")
+    expect(result).toBe("very_long_tool_name_that_…")
+    expect(result.length).toBe(26)
+  })
+
+  it("handles empty string", () => {
+    expect(truncateLabel("", 26)).toBe(" ".repeat(26))
   })
 })

--- a/.config/opencode/plugins/model-usage/analyze.tsx
+++ b/.config/opencode/plugins/model-usage/analyze.tsx
@@ -5,7 +5,7 @@ import { existsSync, readFileSync } from "node:fs"
 import { homedir } from "node:os"
 import { log } from "./helpers/debug"
 import { estimateTokens, rawPromptTokens, scaleEntries } from "./helpers/tokens"
-import { buildBar, fmt } from "./helpers/format"
+import { buildBar, fmt, truncateLabel } from "./helpers/format"
 import { loadBaseline } from "./db"
 import type { SystemFragment, SystemSnapshot, SystemSource } from "./types"
 import { makeScrollState } from "./shared/scroll"
@@ -782,7 +782,7 @@ export function registerAnalyzeCommand(api: TuiPluginApi) {
                             <box flexDirection="column" gap={0}>
                               {top.map((entry, i) => (
                                 <text key={entry.label + i} fg={fg}>
-                                  {String(i + 1).padStart(2)}. {entry.label.padEnd(24)}{safeFmt(entry.tokens).padStart(10)} tokens
+                                  {String(i + 1).padStart(2)}. {truncateLabel(entry.label)}{safeFmt(entry.tokens).padStart(10)} tokens
                                 </text>
                               ))}
                             </box>

--- a/.config/opencode/plugins/model-usage/helpers/format.ts
+++ b/.config/opencode/plugins/model-usage/helpers/format.ts
@@ -43,3 +43,8 @@ export function getQuotaLabel(quota: { planType: string; quotaType: string }): s
   if (quota.quotaType === "ai_credits") return "AI Credits"
   return "premium requests"
 }
+
+export function truncateLabel(label: string, maxLen: number = 26): string {
+  if (label.length <= maxLen) return label.padEnd(maxLen)
+  return label.slice(0, maxLen - 1) + "\u2026"
+}

--- a/.config/opencode/plugins/model-usage/sidebar.tsx
+++ b/.config/opencode/plugins/model-usage/sidebar.tsx
@@ -109,15 +109,13 @@ function useTokenTracking(props: { api: TuiPluginApi; sessionID: string }) {
     loadedTokenRootSessionID = sessionID
   }
 
-  // Track peak context size (input + cacheRead + output) per session.
+  // Track peak input tokens (input + cacheRead — no output) per session.
   // `tokens.cache.read` is the full cached context re-sent every API call — summing across all
   // calls inflates the count (e.g. 514k for a 53k conversation).  Instead, we record the
-  // maximum full-call token count (input + cacheRead + output) per session and sum those peaks
-  // across sessions. Including output in the peak makes the ↑ figure match the OpenCode context
-  // bar (which shows total conversation size including the last response).
-  // Cost is accumulated via info.cost deltas from the API.
-  function updatePeakContext(sessionId: string, inputTok: number, cacheReadTok: number, outputTok: number) {
-    const contextSize = inputTok + cacheReadTok + outputTok
+  // maximum input-prompt token count (input + cacheRead) per session and sum those peaks
+  // across sessions. Output is shown separately on the ↓ line.
+  function updatePeakContext(sessionId: string, inputTok: number, cacheReadTok: number, _outputTok: number) {
+    const contextSize = inputTok + cacheReadTok
     const prev = peakPerSession.get(sessionId) ?? 0
     if (contextSize > prev) {
       const delta = contextSize - prev
@@ -409,12 +407,13 @@ function UsageSidebar(props: { api: TuiPluginApi; session_id: string }) {
         if (trackedSessions.has(evtSID) && msg.role === "assistant") {
           const info = msg as AssistantMessage
           const msgId = info.id
-          if (msgId) {
-            const inputTok: number = info.tokens?.input ?? 0
-            const cacheReadTok: number = info.tokens?.cache?.read ?? 0
-            const outputTok: number = info.tokens?.output ?? 0
-            const msgCost: number = info.cost ?? 0
-            if (inputTok > 0 || cacheReadTok > 0 || outputTok > 0 || msgCost > 0) {
+            if (msgId) {
+              const inputTok: number = info.tokens?.input ?? 0
+              const cacheReadTok: number = info.tokens?.cache?.read ?? 0
+              const outputTok: number = info.tokens?.output ?? 0
+              const msgCost: number = info.cost ?? 0
+              if (inputTok > 0 || cacheReadTok > 0 || outputTok > 0 || msgCost > 0) {
+                log("message.updated: msgId:", msgId, "session:", evtSID, "input:", inputTok, "cacheRead:", cacheReadTok, "output:", outputTok, "cost:", msgCost, "tokens:", JSON.stringify(info.tokens), "model:", info.modelID)
               const prevSnapshot = processedAssistantMessages.get(msgId) ?? { input: 0, cacheRead: 0, output: 0, cost: 0 }
               const deltaInput = Math.max(0, inputTok - prevSnapshot.input)
               const deltaCacheRead = Math.max(0, cacheReadTok - prevSnapshot.cacheRead)

--- a/.config/opencode/plugins/model-usage/sidebar.tsx
+++ b/.config/opencode/plugins/model-usage/sidebar.tsx
@@ -413,7 +413,7 @@ function UsageSidebar(props: { api: TuiPluginApi; session_id: string }) {
               const outputTok: number = info.tokens?.output ?? 0
               const msgCost: number = info.cost ?? 0
               if (inputTok > 0 || cacheReadTok > 0 || outputTok > 0 || msgCost > 0) {
-                log("message.updated: msgId:", msgId, "session:", evtSID, "input:", inputTok, "cacheRead:", cacheReadTok, "output:", outputTok, "cost:", msgCost, "tokens:", JSON.stringify(info.tokens), "model:", info.modelID)
+                log("message.updated: msgId:", msgId, "session:", evtSID, "provider:", info.providerID, "model:", info.modelID, "input:", inputTok, "cacheRead:", cacheReadTok, "output:", outputTok, "cost:", msgCost, "tokens:", JSON.stringify(info.tokens))
               const prevSnapshot = processedAssistantMessages.get(msgId) ?? { input: 0, cacheRead: 0, output: 0, cost: 0 }
               const deltaInput = Math.max(0, inputTok - prevSnapshot.input)
               const deltaCacheRead = Math.max(0, cacheReadTok - prevSnapshot.cacheRead)


### PR DESCRIPTION
Closes #35.

## 📋 Changelist Summary
Fixed Top Contributors tab label truncation to keep alignment with long tool names, and fixed the peak input token display to not include output tokens.

## 💬 Description
Two fixes in the model-usage plugin:

1. **Top Contributors tab label truncation** (`analyze.tsx`, `helpers/format.ts`): Labels longer than 26 characters now truncate with `…` and consistent spacing, fixing alignment breakage in the Top Contributors tab.

2. **Peak input token display** (`sidebar.tsx`): The `↑` token count was including `outputTok` in the peak context calculation, inflating the displayed input value to match the full context window. Fixed to only count `input + cacheRead` tokens, matching the intended "input" label.

## 🐞 Steps to reproduce bug
1. Open the Analyze dialog in a session → go to Top tab with a tool name >26 chars → see misaligned columns
2. Open the sidebar → see `↑` value including output tokens, inflated vs actual input

## ℹ️ Extra info
Temp debug logging was added to `message.updated` handler for ongoing Copilot token flow investigation.

> ⚠️ **Auto-generated description.** This PR was generated by an AI agent and may contain inaccuracies or be incomplete. Please review and correct it before merging.