### PR TITLE
Added weekly and daily granularity toggle to /usage command

### DIFF
--- a/.config/opencode/plugins/model-usage/command.tsx
+++ b/.config/opencode/plugins/model-usage/command.tsx
@@ -169,7 +169,29 @@ function buildHierarchy(rows: RawUsageRow[], monthStartMs: number, monthEndMs: n
     }
   }
 
-  const sortedDays = [...dayMap.values()].sort((a, b) => a.startMs - b.startMs)
+  // Fill in ALL days in the month range (including empty ones) so navigating
+  // to any day within a cached month is instant — no DB query for empty days.
+  const allDays: CachePeriod[] = []
+  for (let dayMs = monthStartMs; dayMs < monthEndMs; dayMs += MS_PER_DAY) {
+    const existing = dayMap.get(dayMs)
+    if (existing) {
+      allDays.push(existing)
+    } else {
+      allDays.push({
+        startMs: dayMs,
+        endMs: dayMs + MS_PER_DAY,
+        inputTokens: 0,
+        outputTokens: 0,
+        totalCost: 0,
+        change: null,
+        lastUpdated: Date.now(),
+        weeks: null,
+        days: null,
+        models: [],
+      })
+    }
+  }
+  const sortedDays = allDays
 
   // Compute per-model breakdown for each day from accumulated data
   for (const day of sortedDays) {
@@ -515,12 +537,13 @@ export function registerUsageCommand(api: TuiPluginApi) {
             if (gran === "month") {
               if (!forceRefresh) {
                 const fileCached = getMonthCache(startMs)
-                if (fileCached?.models && fileCached.models.length > 0) {
+                if (fileCached) {
+                  const models = fileCached.models ?? []
                   const isCurrent = isCurrentMonth(startMs)
                   const isStale = isCurrent && (Date.now() - fileCached.lastUpdated) >= CACHE_TTL_MS
                   if (!isStale) {
                     const data: UsageData = {
-                      models: fileCached.models,
+                      models,
                       totalInput: fileCached.inputTokens,
                       totalOutput: fileCached.outputTokens,
                       totalCost: fileCached.totalCost,
@@ -543,12 +566,13 @@ export function registerUsageCommand(api: TuiPluginApi) {
                 const monthCached = getMonthCache(monthStart)
                 const periodList = gran === "week" ? monthCached?.weeks : monthCached?.days
                 const period = periodList?.find(p => p.startMs === startMs)
-                if (period?.models && period.models.length > 0) {
+                if (period) {
+                  const models = period.models ?? []
                   const isCurrent = gran === "week" ? weekOffset() === 0 : dayOffset() === 0
                   const isStale = isCurrent && (Date.now() - period.lastUpdated) >= CACHE_TTL_MS
                   if (!isStale) {
                     const data: UsageData = {
-                      models: period.models,
+                      models,
                       totalInput: period.inputTokens,
                       totalOutput: period.outputTokens,
                       totalCost: period.totalCost,
@@ -574,7 +598,7 @@ export function registerUsageCommand(api: TuiPluginApi) {
                           const adjList2 = gran === "week" ? adjCached?.weeks : adjCached?.days
                           adjPeriod = adjList2?.find(p => p.startMs === adjStart)
                         }
-                        if (adjPeriod?.models && adjPeriod.models.length > 0) {
+                        if (adjPeriod) {
                           modelCache.set(adjKey, {
                             models: adjPeriod.models,
                             totalInput: adjPeriod.inputTokens,

--- a/.config/opencode/plugins/model-usage/command.tsx
+++ b/.config/opencode/plugins/model-usage/command.tsx
@@ -4,25 +4,43 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs"
 import { homedir } from "node:os"
 
 import { onMount, onCleanup, createSignal } from "solid-js"
-import { getMonthInfo, isCurrentMonth } from "./helpers/dates"
-import { fmt, fmtCost, buildBar } from "./helpers/format"
-import type { UsageData } from "./types"
-import { queryUsage, getEarliestUsageDate } from "./db"
+import { getMonthInfo, isCurrentMonth, getWeekMonday, getWeekInfo } from "./helpers/dates"
+import { fmt, fmtCost, buildBar, formatPercentDiff } from "./helpers/format"
+import type { UsageData, ModelUsage } from "./types"
+import { getEarliestUsageDate, fetchRawRows, type RawUsageRow } from "./db"
 import { makeScrollState } from "./shared/scroll"
 import { registerDialogKeyLayer } from "./shared/keys"
+
+const MS_PER_DAY = 86_400_000
+const CACHE_TTL_MS = 60_000  // 60 seconds — current period cache is stale after this
+
+// ─── Types ─────────────────────────────────────────────────────────────────
+type Granularity = "month" | "week" | "day"
+
+interface CachePeriod {
+  startMs: number
+  endMs: number
+  inputTokens: number
+  outputTokens: number
+  totalCost: number
+  change: number | null
+  lastUpdated: number
+  weeks: CachePeriod[] | null
+  days: CachePeriod[] | null
+  models: ModelUsage[] | null
+}
+
+interface UsageCache {
+  version: number
+  months: Record<string, CachePeriod>
+}
 
 // ─── Persistent multi-month cache ─────────────────────────────────────────
 const CACHE_DIR = `${homedir()}/.config/opencode/plugins/model-usage`
 const CACHE_FILE = `${CACHE_DIR}/.usage-cache.json`
-const CACHE_TTL_MS = 60_000
 
-interface CacheEntry {
-  result: UsageData | { error: string }
-  month: number  // startMs
-  cachedAt: number
-}
 
-let memoryCache = new Map<number, CacheEntry>()
+let usageCache: UsageCache = { version: 2, months: {} }
 
 function ensureCacheDir() {
   try { mkdirSync(CACHE_DIR, { recursive: true }) } catch { /* ignore */ }
@@ -34,11 +52,10 @@ function loadDiskCache() {
     if (existsSync(CACHE_FILE)) {
       const raw = readFileSync(CACHE_FILE, "utf-8")
       const data = JSON.parse(raw)
-      if (data.months) {
-        for (const [key, val] of Object.entries(data.months)) {
-          memoryCache.set(Number(key), val as CacheEntry)
-        }
+      if (data.version === 2 && data.months) {
+        usageCache = data as UsageCache
       }
+      // else: old format (version 1 or missing) — start fresh
     }
   } catch { /* ignore */ }
 }
@@ -46,25 +63,273 @@ function loadDiskCache() {
 function saveDiskCache() {
   ensureCacheDir()
   try {
-    const obj: Record<string, CacheEntry> = {}
-    for (const [key, val] of memoryCache.entries()) {
-      obj[String(key)] = val
-    }
-    writeFileSync(CACHE_FILE, JSON.stringify({ months: obj }, null, 2))
+    writeFileSync(CACHE_FILE, JSON.stringify(usageCache, null, 2))
   } catch { /* ignore */ }
 }
 
-function getCached(month: number): CacheEntry | undefined {
-  return memoryCache.get(month)
-}
-
-function setCached(month: number, entry: CacheEntry) {
-  memoryCache.set(month, entry)
-  saveDiskCache()
+function getMonthCache(startMs: number): CachePeriod | undefined {
+  return usageCache.months[String(startMs)]
 }
 
 // Load on module init
 loadDiskCache()
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/** Aggregate raw rows into UsageData (per-model breakdown). */
+function computeUsageDataFromRows(rows: RawUsageRow[]): UsageData {
+  const modelMap = new Map<string, ModelUsage>()
+
+  for (const row of rows) {
+    if (!row.provider_id || !row.model_id) continue
+    const key = `${row.provider_id}/${row.model_id}`
+    let existing = modelMap.get(key)
+    if (!existing) {
+      existing = { providerId: row.provider_id, modelId: row.model_id, totalCost: 0, totalInput: 0, totalOutput: 0 }
+      modelMap.set(key, existing)
+    }
+    existing.totalCost += Math.max(0, row.cost ?? 0)
+    existing.totalInput += Math.max(0, row.input_tokens ?? 0)
+    existing.totalOutput += Math.max(0, row.output_tokens ?? 0)
+  }
+
+  const sorted = [...modelMap.values()]
+    .sort((a, b) => (b.totalInput + b.totalOutput) - (a.totalInput + a.totalOutput))
+    .slice(0, 10)
+
+  let totalInput = 0
+  let totalOutput = 0
+  let totalCost = 0
+  for (const m of sorted) {
+    totalInput += m.totalInput
+    totalOutput += m.totalOutput
+    totalCost += m.totalCost
+  }
+
+  return { models: sorted, totalInput, totalOutput, totalCost }
+}
+
+/** Build hierarchical cache tree from raw rows for a given month. */
+function buildHierarchy(rows: RawUsageRow[], monthStartMs: number, monthEndMs: number): CachePeriod {
+  // Bucket rows by day
+  const dayMap = new Map<number, CachePeriod>()
+  const dayModels = new Map<number, Map<string, { providerId: string; modelId: string; totalCost: number; totalInput: number; totalOutput: number }>>()
+  const weekModels = new Map<number, Map<string, { providerId: string; modelId: string; totalCost: number; totalInput: number; totalOutput: number }>>()
+  for (const row of rows) {
+    const dayMs = Math.floor(row.time_created / MS_PER_DAY) * MS_PER_DAY
+    let day = dayMap.get(dayMs)
+    if (!day) {
+      day = {
+        startMs: dayMs,
+        endMs: dayMs + MS_PER_DAY,
+        inputTokens: 0,
+        outputTokens: 0,
+        totalCost: 0,
+        change: null,
+        lastUpdated: Date.now(),
+        weeks: null,
+        days: null,
+        models: null,
+      }
+      dayMap.set(dayMs, day)
+    }
+    day.inputTokens += row.input_tokens
+    day.outputTokens += row.output_tokens
+    day.totalCost += row.cost
+
+    // Accumulate per-model breakdown during the initial pass
+    if (row.provider_id && row.model_id) {
+      let dm = dayModels.get(dayMs)
+      if (!dm) {
+        dm = new Map()
+        dayModels.set(dayMs, dm)
+      }
+      const mk = `${row.provider_id}/${row.model_id}`
+      let me = dm.get(mk)
+      if (!me) {
+        me = { providerId: row.provider_id, modelId: row.model_id, totalCost: 0, totalInput: 0, totalOutput: 0 }
+        dm.set(mk, me)
+      }
+      me.totalCost += Math.max(0, row.cost ?? 0)
+      me.totalInput += Math.max(0, row.input_tokens ?? 0)
+      me.totalOutput += Math.max(0, row.output_tokens ?? 0)
+    }
+
+    // Accumulate per-model breakdown for weeks during the initial pass
+    if (row.provider_id && row.model_id) {
+      const wm = getWeekMonday(new Date(row.time_created)).getTime()
+      let wmap = weekModels.get(wm)
+      if (!wmap) { wmap = new Map(); weekModels.set(wm, wmap) }
+      const mk = `${row.provider_id}/${row.model_id}`
+      let me = wmap.get(mk)
+      if (!me) { me = { providerId: row.provider_id, modelId: row.model_id, totalCost: 0, totalInput: 0, totalOutput: 0 }; wmap.set(mk, me) }
+      me.totalCost += Math.max(0, row.cost ?? 0)
+      me.totalInput += Math.max(0, row.input_tokens ?? 0)
+      me.totalOutput += Math.max(0, row.output_tokens ?? 0)
+    }
+  }
+
+  const sortedDays = [...dayMap.values()].sort((a, b) => a.startMs - b.startMs)
+
+  // Compute per-model breakdown for each day from accumulated data
+  for (const day of sortedDays) {
+    const dm = dayModels.get(day.startMs)
+    if (dm) {
+      day.models = [...dm.values()]
+        .sort((a, b) => (b.totalInput + b.totalOutput) - (a.totalInput + a.totalOutput))
+        .slice(0, 10)
+    } else {
+      day.models = []
+    }
+  }
+
+  // Group days into ISO weeks
+  const weekMap = new Map<number, { weekMonday: number; days: CachePeriod[] }>()
+  for (const day of sortedDays) {
+    const wm = getWeekMonday(new Date(day.startMs)).getTime()
+    let w = weekMap.get(wm)
+    if (!w) {
+      w = { weekMonday: wm, days: [] }
+      weekMap.set(wm, w)
+    }
+    w.days.push(day)
+  }
+
+  const sortedWeekKeys = [...weekMap.keys()].sort((a, b) => a - b)
+  const weeks: CachePeriod[] = sortedWeekKeys.map((wk, i) => {
+    const w = weekMap.get(wk)!
+    const inputTokens = w.days.reduce((s, d) => s + d.inputTokens, 0)
+    const outputTokens = w.days.reduce((s, d) => s + d.outputTokens, 0)
+    const totalCost = w.days.reduce((s, d) => s + d.totalCost, 0)
+
+    // Change vs previous week (within this month's weeks)
+    let change: number | null = null
+    if (i > 0) {
+      const prev = weekMap.get(sortedWeekKeys[i - 1])!
+      const prevTotal = prev.days.reduce((s, d) => s + d.inputTokens + d.outputTokens, 0)
+      const currTotal = inputTokens + outputTokens
+      if (prevTotal > 0) {
+        change = Math.round(((currTotal - prevTotal) / prevTotal) * 100)
+      }
+    }
+
+    // Compute per-model breakdown for this week from accumulated data
+    const wmap = weekModels.get(wk)
+    const weekModelArr = wmap ? [...wmap.values()]
+      .sort((a, b) => (b.totalInput + b.totalOutput) - (a.totalInput + a.totalOutput))
+      .slice(0, 10) : []
+
+    return {
+      startMs: wk,
+      endMs: wk + 7 * MS_PER_DAY,
+      inputTokens,
+      outputTokens,
+      totalCost,
+      change,
+      lastUpdated: Date.now(),
+      weeks: null,
+      days: w.days,
+      models: weekModelArr,
+    }
+  })
+
+  const totalInput = weeks.reduce((s, w) => s + w.inputTokens, 0)
+  const totalOutput = weeks.reduce((s, w) => s + w.outputTokens, 0)
+  const totalCostW = weeks.reduce((s, w) => s + w.totalCost, 0)
+
+  // Compute per-model breakdown for this month and store in cache
+  const monthModels = computeUsageDataFromRows(rows).models
+
+  return {
+    startMs: monthStartMs,
+    endMs: monthEndMs,
+    inputTokens: totalInput,
+    outputTokens: totalOutput,
+    totalCost: totalCostW,
+    change: null, // filled in by updateMonthCache
+    lastUpdated: Date.now(),
+    weeks,
+    days: sortedDays,
+    models: monthModels,
+  }
+}
+
+/** Store a month entry in the cache, computing change vs adjacent months. */
+function updateMonthCache(period: CachePeriod) {
+  const key = String(period.startMs)
+
+  // Compute change vs previous month
+  const prevDate = new Date(period.startMs)
+  let prevMonth = prevDate.getUTCMonth() - 1
+  let prevYear = prevDate.getUTCFullYear()
+  if (prevMonth < 0) { prevMonth = 11; prevYear-- }
+  const prevMonthStartMs = Date.UTC(prevYear, prevMonth, 1)
+  const prevEntry = usageCache.months[String(prevMonthStartMs)]
+  if (prevEntry) {
+    const prevTotal = prevEntry.inputTokens + prevEntry.outputTokens
+    const currTotal = period.inputTokens + period.outputTokens
+    if (prevTotal > 0) {
+      period.change = Math.round(((currTotal - prevTotal) / prevTotal) * 100)
+    }
+  }
+
+  // Update first week's change vs last week of previous month
+  if (period.weeks && period.weeks.length > 0) {
+    const firstWeek = period.weeks[0]
+    if (firstWeek.change === null && prevEntry?.weeks?.length) {
+      const lastWeek = prevEntry.weeks[prevEntry.weeks.length - 1]
+      const lastWeekTotal = lastWeek.inputTokens + lastWeek.outputTokens
+      const firstWeekTotal = firstWeek.inputTokens + firstWeek.outputTokens
+      if (lastWeekTotal > 0) {
+        firstWeek.change = Math.round(((firstWeekTotal - lastWeekTotal) / lastWeekTotal) * 100)
+      }
+    }
+  }
+
+  usageCache.months[key] = period
+
+  // Also update next month's change if it exists
+  let nextMonth = prevDate.getUTCMonth() + 1
+  let nextYear = prevDate.getUTCFullYear()
+  if (nextMonth > 11) { nextMonth = 0; nextYear++ }
+  const nextMonthStartMs = Date.UTC(nextYear, nextMonth, 1)
+  const nextEntry = usageCache.months[String(nextMonthStartMs)]
+  if (nextEntry) {
+    const currTotal = period.inputTokens + period.outputTokens
+    const nextTotal = nextEntry.inputTokens + nextEntry.outputTokens
+    if (currTotal > 0) {
+      nextEntry.change = Math.round(((nextTotal - currTotal) / currTotal) * 100)
+    }
+  }
+
+  saveDiskCache()
+}
+
+/** Get the previous month's startMs given a month timestamp. */
+function getPrevMonthStartMs(ms: number): number {
+  const d = new Date(ms)
+  let m = d.getUTCMonth() - 1
+  let y = d.getUTCFullYear()
+  if (m < 0) { m = 11; y-- }
+  return Date.UTC(y, m, 1)
+}
+
+/** Get the month and year that contains a given timestamp. */
+function getMonthFromMs(ms: number): { year: number; month: number } {
+  const d = new Date(ms)
+  return { year: d.getUTCFullYear(), month: d.getUTCMonth() }
+}
+
+/** Get the first Monday that falls within a given month. */
+function getFirstMondayInMonth(year: number, month: number): number {
+  const monthStartMs = Date.UTC(year, month, 1)
+  const d = new Date(monthStartMs)
+  const day = d.getUTCDay() // 0=Sun, 1=Mon, ..., 6=Sat
+  const daysUntilMonday = (8 - day) % 7
+  return monthStartMs + daysUntilMonday * MS_PER_DAY
+}
+
+// ─── Command registration ──────────────────────────────────────────────────
 
 export function registerUsageCommand(api: TuiPluginApi) {
   api.keymap.registerLayer({
@@ -79,7 +344,6 @@ export function registerUsageCommand(api: TuiPluginApi) {
           const theme = api.theme.current
           const dbPath = `${homedir()}/.local/share/opencode/opencode.db`
           const now = new Date()
-          const currentMonthStart = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)
 
           const fg = theme?.foreground ?? "#ffffff"
           const muted = theme?.muted ?? "#888888"
@@ -100,8 +364,10 @@ export function registerUsageCommand(api: TuiPluginApi) {
             return
           }
 
-          // ── Determine earliest month with data ──────────────────────────
+          // ── Determine earliest data bounds ──────────────────────────────
           let minMonthOffset = 0
+          let minWeekOffset = 0
+          let minDayOffset = 0
           {
             const earliestMs = getEarliestUsageDate(dbPath)
             if (earliestMs != null) {
@@ -112,87 +378,290 @@ export function registerUsageCommand(api: TuiPluginApi) {
               const currentMonth = now.getUTCMonth()
               const monthsBack = (currentYear * 12 + currentMonth) - (earliestYear * 12 + earliestMonth)
               minMonthOffset = -monthsBack
+
+              // Week offset
+              const earliestWeekMonday = getWeekMonday(earliestDate).getTime()
+              const currentWeekMonday = getWeekMonday(new Date()).getTime()
+              if (earliestWeekMonday < currentWeekMonday) {
+                const diffWeeks = Math.floor((currentWeekMonday - earliestWeekMonday) / (7 * MS_PER_DAY))
+                minWeekOffset = -diffWeeks
+              }
+
+              // Day offset
+              const earliestDayStart = Date.UTC(earliestDate.getUTCFullYear(), earliestDate.getUTCMonth(), earliestDate.getUTCDate())
+              const currentDayStart = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+              if (earliestDayStart < currentDayStart) {
+                const diffDays = Math.floor((currentDayStart - earliestDayStart) / MS_PER_DAY)
+                minDayOffset = -diffDays
+              }
             }
           }
 
           // ── State ────────────────────────────────────────────────────────
+          const [granularity, setGranularity] = createSignal<Granularity>("month")
           const [monthOffset, setMonthOffset] = createSignal(0)
+          const [weekOffset, setWeekOffset] = createSignal(0)
+          const [dayOffset, setDayOffset] = createSignal(0)
           const scroll = makeScrollState(createSignal)
 
-          const computeMonth = () => {
-            const m = now.getUTCMonth() + monthOffset()
-            const y = now.getUTCFullYear() + Math.floor(m / 12)
-            const month = ((m % 12) + 12) % 12
-            const { startMs, endMs, label } = getMonthInfo(y, month)
-            return { startMs, endMs, label }
+          const computeWindow = () => {
+            if (granularity() === "month") {
+              const m = now.getUTCMonth() + monthOffset()
+              const y = now.getUTCFullYear() + Math.floor(m / 12)
+              const month = ((m % 12) + 12) % 12
+              const { startMs, endMs, label } = getMonthInfo(y, month)
+              return { startMs, endMs, label }
+            } else if (granularity() === "week") {
+              const currentMonday = getWeekMonday(now)
+              const targetMonday = new Date(currentMonday.getTime() + weekOffset() * 7 * MS_PER_DAY)
+              const { startMs, endMs, label } = getWeekInfo(targetMonday)
+              return { startMs, endMs, label }
+            } else {
+              // day mode
+              const currentDayStart = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+              const targetDayMs = currentDayStart + dayOffset() * MS_PER_DAY
+              const startMs = targetDayMs
+              const endMs = startMs + MS_PER_DAY
+              const d = new Date(startMs)
+              const label = d.toLocaleString("en-US", { weekday: "short", month: "short", day: "numeric", timeZone: "UTC" })
+              return { startMs, endMs, label }
+            }
           }
 
           const [viewState, setViewState] = createSignal<"loading" | "error" | UsageData>("loading")
           const [errorMsg, setErrorMsg] = createSignal<string>("")
           const [hasLoadedOnce, setHasLoadedOnce] = createSignal(false)
+          const [diffInfo, setDiffInfo] = createSignal<{ arrow: string; text: string }>({ arrow: "\u2014", text: "\u2014" })
 
-          function loadMonth(forceRefresh: boolean = false) {
-            const { startMs, endMs } = computeMonth()
-            const isCurrent = isCurrentMonth(startMs)
+          // In-memory per-model cache for instant navigation
+          // Keyed by "{granularity}:{startMs}" — dies with the dialog
+          const modelCache = new Map<string, UsageData>()
 
-            // Past month: only trust cache if written after month ended (complete data)
-            if (!isCurrent) {
-              const cached = getCached(startMs)
-              if (cached && cached.cachedAt >= endMs) {
-                // Cache was written after the month ended — data is complete, use it
-                const data = cached.result
-                if ("error" in data) {
-                  setErrorMsg(data.error)
-                  setViewState("error")
-                } else {
-                  setViewState(data)
-                }
-                if (!hasLoadedOnce()) setHasLoadedOnce(true)
-                return
-              }
-              // Cache is stale (cachedAt < endMs) or missing — show stale cache as placeholder if available
-              if (cached && !("error" in cached.result)) {
-                setViewState(cached.result as UsageData)
-              }
-              // fall through to refetch
-            }
+          function modelCacheKey(gran: Granularity, startMs: number): string {
+            return `${gran}:${startMs}`
+          }
 
-            // Current month: check cache freshness unless forced refresh
-            if (!forceRefresh) {
-              const cached = getCached(startMs)
-              if (cached && (Date.now() - cached.cachedAt) < CACHE_TTL_MS) {
-                const data = cached.result
-                if ("error" in data) {
-                  setErrorMsg(data.error)
-                  setViewState("error")
-                } else {
-                  setViewState(data)
-                }
-                if (!hasLoadedOnce()) setHasLoadedOnce(true)
-                return
-              }
-            }
+          // ── Data loading ────────────────────────────────────────────────
 
-            // Show stale cache as placeholder if available
-            if (!forceRefresh) {
-              const cached = getCached(startMs)
-              if (cached && !("error" in cached.result)) {
-                setViewState(cached.result as UsageData)
-              }
-            }
+          function computeAndSetDiff(startMs: number, currentTotal: number) {
+            const gran = granularity()
+            let previousTotal: number | null = null
 
-            // Background query
-            setTimeout(() => {
-              const result = queryUsage(dbPath, startMs, endMs)
-              setCached(startMs, { result, month: startMs, cachedAt: Date.now() })
-              if ("error" in result) {
-                setErrorMsg(result.error)
-                setViewState("error")
+            if (gran === "month") {
+              const prevStartMs = getPrevMonthStartMs(startMs)
+              const prevCached = getMonthCache(prevStartMs)
+              if (prevCached) {
+                previousTotal = prevCached.inputTokens + prevCached.outputTokens
               } else {
-                setViewState(result)
+                const prevRows = fetchRawRows(dbPath, prevStartMs, startMs)
+                if (!("error" in prevRows)) {
+                  previousTotal = prevRows.reduce((s, r) => s + r.input_tokens + r.output_tokens, 0)
+                }
               }
+            } else {
+              const periodMs = gran === "week" ? 7 * MS_PER_DAY : MS_PER_DAY
+              const prevStartMs = startMs - periodMs
+              const prevEndMs = startMs
+
+              // Check current month cache
+              const currMonthStart = Date.UTC(new Date(startMs).getUTCFullYear(), new Date(startMs).getUTCMonth(), 1)
+              const currCached = getMonthCache(currMonthStart)
+              const periodField: "weeks" | "days" = gran === "week" ? "weeks" : "days"
+              const currList = currCached?.[periodField]
+              const prevPeriod = currList?.find((p: CachePeriod) => p.startMs === prevStartMs)
+              if (prevPeriod) {
+                previousTotal = prevPeriod.inputTokens + prevPeriod.outputTokens
+              }
+
+              if (previousTotal === null) {
+                const prevMonthStart = Date.UTC(new Date(prevStartMs).getUTCFullYear(), new Date(prevStartMs).getUTCMonth(), 1)
+                const prevCached = getMonthCache(prevMonthStart)
+                const prevList = prevCached?.[periodField]
+                const prevP = prevList?.find((p: CachePeriod) => p.startMs === prevStartMs)
+                if (prevP) {
+                  previousTotal = prevP.inputTokens + prevP.outputTokens
+                }
+              }
+
+              if (previousTotal === null) {
+                const prevRows = fetchRawRows(dbPath, prevStartMs, prevEndMs)
+                if (!("error" in prevRows)) {
+                  previousTotal = prevRows.reduce((s, r) => s + r.input_tokens + r.output_tokens, 0)
+                }
+              }
+            }
+
+            setDiffInfo(formatPercentDiff(currentTotal, previousTotal))
+          }
+
+          function loadData(forceRefresh: boolean = false) {
+            const { startMs, endMs } = computeWindow()
+            const gran = granularity()
+            const cacheKey = modelCacheKey(gran, startMs)
+
+            // Check in-memory cache first
+            if (!forceRefresh) {
+              const cachedModelData = modelCache.get(cacheKey)
+              if (cachedModelData) {
+                setViewState(cachedModelData)
+                const currentTotal = cachedModelData.totalInput + cachedModelData.totalOutput
+                computeAndSetDiff(startMs, currentTotal)
+                if (!hasLoadedOnce()) setHasLoadedOnce(true)
+                return  // Instant — no DB query needed
+              }
+            }
+
+            // Check file cache for stored model breakdown (all granularities)
+            if (gran === "month") {
+              if (!forceRefresh) {
+                const fileCached = getMonthCache(startMs)
+                if (fileCached?.models && fileCached.models.length > 0) {
+                  const isCurrent = isCurrentMonth(startMs)
+                  const isStale = isCurrent && (Date.now() - fileCached.lastUpdated) >= CACHE_TTL_MS
+                  if (!isStale) {
+                    const data: UsageData = {
+                      models: fileCached.models,
+                      totalInput: fileCached.inputTokens,
+                      totalOutput: fileCached.outputTokens,
+                      totalCost: fileCached.totalCost,
+                    }
+                    setViewState(data)
+                    modelCache.set(cacheKey, data)
+
+                    const currentTotal = fileCached.inputTokens + fileCached.outputTokens
+                    computeAndSetDiff(startMs, currentTotal)
+
+                    if (!hasLoadedOnce()) setHasLoadedOnce(true)
+                    return
+                  }
+                }
+              }
+            } else if (gran === "week" || gran === "day") {
+              if (!forceRefresh) {
+                // For week/day: look up the parent month cache, then find the specific week/day
+                const monthStart = Date.UTC(new Date(startMs).getUTCFullYear(), new Date(startMs).getUTCMonth(), 1)
+                const monthCached = getMonthCache(monthStart)
+                const periodList = gran === "week" ? monthCached?.weeks : monthCached?.days
+                const period = periodList?.find(p => p.startMs === startMs)
+                if (period?.models && period.models.length > 0) {
+                  const isCurrent = gran === "week" ? weekOffset() === 0 : dayOffset() === 0
+                  const isStale = isCurrent && (Date.now() - period.lastUpdated) >= CACHE_TTL_MS
+                  if (!isStale) {
+                    const data: UsageData = {
+                      models: period.models,
+                      totalInput: period.inputTokens,
+                      totalOutput: period.outputTokens,
+                      totalCost: period.totalCost,
+                    }
+                    setViewState(data)
+                    modelCache.set(cacheKey, data)
+
+                    const currentTotal = period.inputTokens + period.outputTokens
+                    computeAndSetDiff(startMs, currentTotal)
+
+                    // Background prefetch of adjacent periods from file cache
+                    setTimeout(() => {
+                      const periodMs = gran === "week" ? 7 * MS_PER_DAY : MS_PER_DAY
+                      for (const adjStart of [startMs - periodMs, startMs + periodMs]) {
+                        const adjKey = modelCacheKey(gran, adjStart)
+                        if (modelCache.has(adjKey)) continue
+                        // Try current month's cache first, then adjacent month
+                        let adjPeriod: CachePeriod | undefined
+                        adjPeriod = periodList?.find(p => p.startMs === adjStart)
+                        if (!adjPeriod) {
+                          const adjMonthStart = Date.UTC(new Date(adjStart).getUTCFullYear(), new Date(adjStart).getUTCMonth(), 1)
+                          const adjCached = getMonthCache(adjMonthStart)
+                          const adjList2 = gran === "week" ? adjCached?.weeks : adjCached?.days
+                          adjPeriod = adjList2?.find(p => p.startMs === adjStart)
+                        }
+                        if (adjPeriod?.models && adjPeriod.models.length > 0) {
+                          modelCache.set(adjKey, {
+                            models: adjPeriod.models,
+                            totalInput: adjPeriod.inputTokens,
+                            totalOutput: adjPeriod.outputTokens,
+                            totalCost: adjPeriod.totalCost,
+                          })
+                        }
+                      }
+                    }, 10)
+
+                    if (!hasLoadedOnce()) setHasLoadedOnce(true)
+                    return
+                  }
+                }
+              }
+            }
+
+            // Background fetch
+            setTimeout(() => {
+              const rowsResult = fetchRawRows(dbPath, startMs, endMs)
+              if ("error" in rowsResult) {
+                setErrorMsg(rowsResult.error)
+                setViewState("error")
+                if (!hasLoadedOnce()) setHasLoadedOnce(true)
+                return
+              }
+
+              const rows = rowsResult
+
+              // Compute per-model breakdown for UI
+              const usageData = computeUsageDataFromRows(rows)
+              modelCache.set(modelCacheKey(granularity(), startMs), usageData)
+              setViewState(usageData)
+
+              // For month mode: build hierarchical cache
+              if (granularity() === "month") {
+                const monthStartMs = startMs
+                const monthEndMs = endMs
+                const period = buildHierarchy(rows, monthStartMs, monthEndMs)
+                updateMonthCache(period)
+              }
+
+              computeAndSetDiff(startMs, usageData.totalInput + usageData.totalOutput)
+
+              // Background prefetch: cache adjacent periods for instant navigation
+              setTimeout(() => {
+                if (gran === "month") {
+                  // Prefetch previous and next month
+                  for (const adjStartMs of [getPrevMonthStartMs(startMs), startMs + 32 * MS_PER_DAY]) {
+                    // normalize next month start
+                    const d = new Date(adjStartMs)
+                    const adjNorm = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1)
+                    const adjKey = modelCacheKey("month", adjNorm)
+                    if (modelCache.has(adjKey)) continue
+                    const adjEndMs = Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + 1, 1)
+                    const adjRows = fetchRawRows(dbPath, adjNorm, adjEndMs)
+                    if ("error" in adjRows || adjRows.length === 0) continue
+                    modelCache.set(adjKey, computeUsageDataFromRows(adjRows))
+                  }
+                } else {
+                  // Prefetch previous and next period (week or day)
+                  const periodMs = gran === "week" ? 7 * MS_PER_DAY : MS_PER_DAY
+                  for (const adjStart of [startMs - periodMs, startMs + periodMs]) {
+                    const adjKey = modelCacheKey(gran, adjStart)
+                    if (modelCache.has(adjKey)) continue
+                    const adjRows = fetchRawRows(dbPath, adjStart, adjStart + periodMs)
+                    if ("error" in adjRows || adjRows.length === 0) continue
+                    const adjData = computeUsageDataFromRows(adjRows)
+                    modelCache.set(adjKey, adjData)
+                    // Also persist to file cache
+                    const adjMonthStart = Date.UTC(new Date(adjStart).getUTCFullYear(), new Date(adjStart).getUTCMonth(), 1)
+                    const adjMonth = getMonthCache(adjMonthStart)
+                    if (adjMonth) {
+                      const periodList = gran === "week" ? adjMonth.weeks : adjMonth.days
+                      const period = periodList?.find(p => p.startMs === adjStart)
+                      if (period) {
+                        period.models = adjData.models
+                        period.lastUpdated = Date.now()
+                        saveDiskCache()
+                      }
+                    }
+                  }
+                }
+              }, 50)
+
               if (!hasLoadedOnce()) setHasLoadedOnce(true)
-            }, 10)
+            }, 0)
           }
 
           // ── Handle key presses ──────────────────────────────────────────
@@ -200,31 +669,108 @@ export function registerUsageCommand(api: TuiPluginApi) {
 
           function handleKey(key: string) {
             if (key === "left" || key === "h") {
-              if (monthOffset() <= minMonthOffset) return true  // hard cap: no older months available
-              setMonthOffset(p => p - 1)
+              if (granularity() === "month") {
+                if (monthOffset() <= minMonthOffset) return true
+                setMonthOffset(p => p - 1)
+              } else if (granularity() === "week") {
+                if (weekOffset() <= minWeekOffset) return true
+                setWeekOffset(p => p - 1)
+              } else {
+                if (dayOffset() <= minDayOffset) return true
+                setDayOffset(p => p - 1)
+              }
               scroll.scrollToTop()
-              setTimeout(() => loadMonth(), 10)
+              setTimeout(loadData, 0)
               return true
             }
             if (key === "right" || key === "l") {
-              if (monthOffset() >= 0) return true  // already at current month, don't go past
-              setMonthOffset(p => p + 1)
+              if (granularity() === "month") {
+                if (monthOffset() >= 0) return true
+                setMonthOffset(p => p + 1)
+              } else if (granularity() === "week") {
+                if (weekOffset() >= 0) return true
+                setWeekOffset(p => p + 1)
+              } else {
+                if (dayOffset() >= 0) return true
+                setDayOffset(p => p + 1)
+              }
               scroll.scrollToTop()
-              setTimeout(() => loadMonth(), 10)
+              setTimeout(loadData, 0)
               return true
             }
             if (key === "r") {
-              const { startMs } = computeMonth()
-              if (isCurrentMonth(startMs)) {
-                loadMonth(true)
+              const { startMs } = computeWindow()
+              const gran = granularity()
+              const isCurrent = gran === "month"
+                ? isCurrentMonth(startMs)
+                : gran === "week"
+                  ? weekOffset() === 0
+                  : dayOffset() === 0
+              if (isCurrent) {
+                modelCache.delete(modelCacheKey(gran, startMs))
+                loadData(true)
               }
               return true
             }
             if (key === "t") {
-              if (monthOffset() === 0) return true  // already at current month
-              setMonthOffset(0)
+              if (granularity() === "month") {
+                if (monthOffset() === 0) return true
+                setMonthOffset(0)
+              } else if (granularity() === "week") {
+                if (weekOffset() === 0) return true
+                setWeekOffset(0)
+              } else {
+                if (dayOffset() === 0) return true
+                setDayOffset(0)
+              }
               scroll.scrollToTop()
-              setTimeout(() => loadMonth(), 10)
+              setTimeout(loadData, 0)
+              return true
+            }
+            if (key === "m") {
+              if (granularity() === "month") {
+                // Month → Week
+                let newWeekOffset = 0
+                if (monthOffset() !== 0) {
+                  const m = now.getUTCMonth() + monthOffset()
+                  const y = now.getUTCFullYear() + Math.floor(m / 12)
+                  const month = ((m % 12) + 12) % 12
+                  const firstMondayMs = getFirstMondayInMonth(y, month)
+                  const currentWeekMonday = getWeekMonday(now).getTime()
+                  const diffWeeks = Math.round((currentWeekMonday - firstMondayMs) / (7 * MS_PER_DAY))
+                  newWeekOffset = -diffWeeks
+                }
+                setGranularity("week")
+                setWeekOffset(newWeekOffset)
+              } else if (granularity() === "week") {
+                // Week → Day
+                let newDayOffset = 0
+                if (weekOffset() !== 0) {
+                  const currentMonday = getWeekMonday(now)
+                  const targetMonday = new Date(currentMonday.getTime() + weekOffset() * 7 * MS_PER_DAY)
+                  const currentDayStart = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+                  const targetDayStart = Date.UTC(targetMonday.getUTCFullYear(), targetMonday.getUTCMonth(), targetMonday.getUTCDate())
+                  const diffDays = Math.round((targetDayStart - currentDayStart) / MS_PER_DAY)
+                  newDayOffset = diffDays
+                }
+                setGranularity("day")
+                setDayOffset(newDayOffset)
+              } else {
+                // Day → Month
+                let newMonthOffset = 0
+                if (dayOffset() !== 0) {
+                  const currentDayStart = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+                  const targetDayMs = currentDayStart + dayOffset() * MS_PER_DAY
+                  const d = new Date(targetDayMs)
+                  const currentYear = now.getUTCFullYear()
+                  const currentMonth = now.getUTCMonth()
+                  newMonthOffset = (d.getUTCFullYear() * 12 + d.getUTCMonth()) - (currentYear * 12 + currentMonth)
+                }
+                setGranularity("month")
+                setMonthOffset(newMonthOffset)
+              }
+              scroll.scrollToTop()
+              setTimeout(loadData, 0)
               return true
             }
             if (key === "up") {
@@ -238,48 +784,52 @@ export function registerUsageCommand(api: TuiPluginApi) {
 
           // ── Reactive dialog ─────────────────────────────────────────────
           api.ui.dialog.replace(() => {
-            const { label } = computeMonth()
-            const offset = monthOffset()
+            const { label } = computeWindow()
+            const gran = granularity()
+            const offset = gran === "month" ? monthOffset() : gran === "week" ? weekOffset() : dayOffset()
+            const minOffset = gran === "month" ? minMonthOffset : gran === "week" ? minWeekOffset : minDayOffset
+
             let arrows: string
-            if (minMonthOffset === 0) {
-              arrows = ""                    // Case 4: only month available
+            if (minOffset === 0) {
+              arrows = ""
             } else if (offset >= 0) {
-              arrows = " ←"                  // Case 1: at current month, can only go older
-            } else if (offset <= minMonthOffset) {
-              arrows = " →"                  // Case 3: at oldest month, can only go newer
+              arrows = " ←"
+            } else if (offset <= minOffset) {
+              arrows = " →"
             } else {
-              arrows = " ← →"                // Case 2: middle month, both directions
+              arrows = " ← →"
             }
+
             onMount(() => {
               api.ui.dialog.setSize("large")
-              // Register dialog key layer
               cleanupKeyLayer = registerDialogKeyLayer(api, {
                 bindings: [
-                  { key: "left",  cmd: "usage.navLeft",  desc: "Previous month" },
-                  { key: "h",     cmd: "usage.navLeft",  desc: "Previous month" },
-                  { key: "right", cmd: "usage.navRight", desc: "Next month" },
-                  { key: "l",     cmd: "usage.navRight", desc: "Next month" },
+                  { key: "left",  cmd: "usage.navLeft",  desc: "Previous" },
+                  { key: "h",     cmd: "usage.navLeft",  desc: "Previous" },
+                  { key: "right", cmd: "usage.navRight", desc: "Next" },
+                  { key: "l",     cmd: "usage.navRight", desc: "Next" },
                   { key: "r",     cmd: "usage.reload",   desc: "Reload" },
-                  { key: "t",     cmd: "usage.today",   desc: "Today" },
-                  { key: "up",   cmd: "usage.scrollUp",   desc: "Scroll up" },
-                  { key: "k",    cmd: "usage.scrollUp",   desc: "Scroll up" },
-                  { key: "down", cmd: "usage.scrollDown", desc: "Scroll down" },
-                  { key: "j",    cmd: "usage.scrollDown", desc: "Scroll down" },
+                  { key: "t",     cmd: "usage.today",    desc: "Today" },
+                  { key: "m",     cmd: "usage.toggleMode", desc: "Toggle mode" },
+                  { key: "up",    cmd: "usage.scrollUp",   desc: "Scroll up" },
+                  { key: "k",     cmd: "usage.scrollUp",   desc: "Scroll up" },
+                  { key: "down",  cmd: "usage.scrollDown", desc: "Scroll down" },
+                  { key: "j",     cmd: "usage.scrollDown", desc: "Scroll down" },
                 ],
                 commands: [
-                  { name: "usage.navLeft",   title: "Previous Month", run: async () => { handleKey("left") } },
-                  { name: "usage.navRight",  title: "Next Month",     run: async () => { handleKey("right") } },
-                  { name: "usage.reload",    title: "Reload Usage",   run: async () => { handleKey("r") } },
-                  { name: "usage.today",    title: "Today",        run: async () => { handleKey("t") } },
-                  { name: "usage.scrollUp",   title: "Scroll Up",   run: async () => { handleKey("up") } },
-                  { name: "usage.scrollDown", title: "Scroll Down", run: async () => { handleKey("down") } },
+                  { name: "usage.navLeft",     title: "Previous",       run: async () => { handleKey("left") } },
+                  { name: "usage.navRight",    title: "Next",           run: async () => { handleKey("right") } },
+                  { name: "usage.reload",      title: "Reload Usage",   run: async () => { handleKey("r") } },
+                  { name: "usage.today",       title: "Today",          run: async () => { handleKey("t") } },
+                  { name: "usage.toggleMode",  title: "Toggle Mode",    run: async () => { handleKey("m") } },
+                  { name: "usage.scrollUp",    title: "Scroll Up",      run: async () => { handleKey("up") } },
+                  { name: "usage.scrollDown",  title: "Scroll Down",    run: async () => { handleKey("down") } },
                 ],
               })
               // Initial load
-              loadMonth()
+              loadData()
               // Background: prefetch past months so navigation is instant
               setTimeout(() => {
-                // Compute earliest month timestamp from the data cap
                 const minMonthYear = now.getUTCFullYear() + Math.floor((now.getUTCMonth() + minMonthOffset) / 12)
                 const minMonthMonth = ((now.getUTCMonth() + minMonthOffset) % 12 + 12) % 12
                 const minPrefetchMs = Date.UTC(minMonthYear, minMonthMonth, 1)
@@ -291,12 +841,19 @@ export function registerUsageCommand(api: TuiPluginApi) {
                   const startMs = Date.UTC(y, m, 1)
                   if (startMs < minPrefetchMs) break
                   const endMs = Date.UTC(y, m + 1, 1)
-                  const existingCache = getCached(startMs)
-                  if (existingCache && existingCache.cachedAt >= endMs) { m--; continue }
-                  const result = queryUsage(dbPath, startMs, endMs)
-                  setCached(startMs, { result, month: startMs, cachedAt: Date.now() })
+
+                  // Skip if already cached with complete data
+                  const existing = getMonthCache(startMs)
+                  if (existing && existing.lastUpdated >= endMs) { m--; continue }
+
+                  const rowsResult = fetchRawRows(dbPath, startMs, endMs)
+                  if ("error" in rowsResult) { m--; continue }
+
+                  const period = buildHierarchy(rowsResult, startMs, endMs)
+                  updateMonthCache(period)
+
                   // Stop if no data this far back
-                  if (!("error" in result) && result.models.length === 0) break
+                  if (period.inputTokens === 0 && period.outputTokens === 0) break
                   m--
                 }
               }, 500)
@@ -312,8 +869,8 @@ export function registerUsageCommand(api: TuiPluginApi) {
               <box paddingLeft={2} paddingRight={2} paddingBottom={1} flexDirection="column" gap={1}>
                 <box flexDirection="row" justifyContent="space-between">
                   <box flexDirection="row" gap={1}>
-                    <text fg={fg}><b>Usage</b></text>
-                    <text fg={muted}>{label}{arrows}</text>
+                    <text fg={fg}><b>Usage{gran === "week" ? " / weekly" : gran === "day" ? " / daily" : ""}</b></text>
+                    <text fg={muted}>{gran === "week" ? `\u2014 ${label}` : label}{arrows}</text>
                   </box>
                   <text fg={muted}>esc</text>
                 </box>
@@ -340,10 +897,14 @@ export function registerUsageCommand(api: TuiPluginApi) {
                       const hasCost = totalCost > 0
                       const emptyResult = models.length === 0
                       return emptyResult ? (
-                        <text fg={muted}>No usage data for {label}.</text>
+                        <text fg={muted}>— No activity for {label}</text>
                       ) : (
                         <box paddingBottom={1}>
-                          <text fg={fg}>Total: {fmt(totalTokens)} tokens{hasCost ? ` (${fmtCost(totalCost)})` : ""}</text>
+                          <text fg={fg}>Total: {fmt(totalTokens)} tokens{hasCost ? ` (${fmtCost(totalCost)})` : ""}{(() => {
+                            const d = diffInfo()
+                            if (d.text === "\u2014") return ""
+                            return `  ${d.arrow} ${d.text}`
+                          })()}</text>
                           <text fg={muted}>  ↑ Input:  {fmt(totalInput)} tokens</text>
                           <text fg={muted}>  ↓ Output: {fmt(totalOutput)} tokens</text>
                           <text> </text>
@@ -357,7 +918,7 @@ export function registerUsageCommand(api: TuiPluginApi) {
                             return (
                               <box key={m.providerId + "/" + m.modelId} flexDirection="column" gap={1}>
                                 <text fg={fg}>{i + 1}. {displayName}</text>
-                                <text fg={muted}>{fmt(modelTokens)} tokens ({pct.toFixed(1)}%){modelHasCost ? ` — ${fmtCost(m.totalCost)}` : ""}</text>
+                                <text fg={muted}>{fmt(modelTokens)} tokens ({pct.toFixed(1)}%){modelHasCost ? ` \u2014 ${fmtCost(m.totalCost)}` : ""}</text>
                                 <text fg={fg}>{buildBar(pct, 50)}</text>
                                 {i < models.length - 1 && <text> </text>}
                               </box>
@@ -376,7 +937,13 @@ export function registerUsageCommand(api: TuiPluginApi) {
                   )
                 })()}
                 {hasLoadedOnce() && (
-                  <text fg={muted}>t today  ·  ← → month  ·  r reload  ·  ↑↓ scroll</text>
+                  <text fg={muted}>
+                    {gran === "month"
+                      ? "t today  ·  ← → month  ·  m mode  ·  r reload  ·  ↑↓ scroll"
+                      : gran === "week"
+                        ? "t today  ·  ← → week  ·  m mode  ·  r reload  ·  ↑↓ scroll"
+                        : "t today  ·  ← → day  ·  m mode  ·  r reload  ·  ↑↓ scroll"}
+                  </text>
                 )}
               </box>
             )

--- a/.config/opencode/plugins/model-usage/db.test.ts
+++ b/.config/opencode/plugins/model-usage/db.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it, beforeEach, afterEach } from "bun:test"
+import { Database } from "bun:sqlite"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { fetchRawRows, type RawUsageRow } from "./db"
+
+// ─── Temp DB helper ────────────────────────────────────────────────────────────
+// Matches the pattern from analyze.test.ts for hermetic temp DBs.
+
+function setupDb(): { dbPath: string; cleanup: () => void } {
+  const dir = mkdtempSync(join(tmpdir(), "opencode-test-"))
+  const dbPath = join(dir, "test.db")
+  const db = new Database(dbPath)
+  db.run(`CREATE TABLE IF NOT EXISTS message (
+    time_created INTEGER,
+    data TEXT
+  )`)
+  db.close()
+  return { dbPath, cleanup: () => rmSync(dir, { recursive: true, force: true }) }
+}
+
+function insertMessage(dbPath: string, timeCreated: number, data: Record<string, unknown>) {
+  const db = new Database(dbPath)
+  try {
+    db.run(`INSERT INTO message (time_created, data) VALUES (?, ?)`, [
+      timeCreated,
+      JSON.stringify(data),
+    ])
+  } finally {
+    db.close()
+  }
+}
+
+// ─── fetchRawRows ──────────────────────────────────────────────────────────────
+
+describe("fetchRawRows", () => {
+  let setup: { dbPath: string; cleanup: () => void }
+  const REFERENCE = Date.UTC(2026, 6, 6, 12, 0, 0) // Jul 6 2026 12:00 UTC (Monday)
+
+  beforeEach(() => {
+    setup = setupDb()
+  })
+
+  afterEach(() => {
+    setup.cleanup()
+  })
+
+  it("empty DB returns empty array (no error)", () => {
+    const result = fetchRawRows(setup.dbPath, 0, REFERENCE + 86_400_000)
+    expect(Array.isArray(result)).toBe(true)
+    expect(result).toHaveLength(0)
+  })
+
+  it("single assistant message within range returns 1 row with correct fields", () => {
+    insertMessage(setup.dbPath, REFERENCE, {
+      role: "assistant",
+      modelID: "gpt-4",
+      providerID: "copilot",
+      cost: 0.05,
+      tokens: { input: 100, output: 50 },
+    })
+
+    const rows = fetchRawRows(setup.dbPath, REFERENCE - 1, REFERENCE + 86_400_000)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].model_id).toBe("gpt-4")
+    expect(rows[0].provider_id).toBe("copilot")
+    expect(rows[0].cost).toBeCloseTo(0.05, 6)
+    expect(rows[0].input_tokens).toBe(100)
+    expect(rows[0].output_tokens).toBe(50)
+  })
+
+  it("message outside range is excluded", () => {
+    // Insert message at REFERENCE but query range that doesn't include it
+    insertMessage(setup.dbPath, REFERENCE, {
+      role: "assistant",
+      modelID: "gpt-4",
+      providerID: "copilot",
+      cost: 0.05,
+      tokens: { input: 100, output: 50 },
+    })
+
+    // Query for a different day entirely
+    const earlier = REFERENCE - 86_400_000 * 3 // 3 days before
+    const rows = fetchRawRows(setup.dbPath, earlier, earlier + 86_400_000)
+    expect(rows).toHaveLength(0)
+  })
+
+  it("non-assistant messages are excluded", () => {
+    insertMessage(setup.dbPath, REFERENCE, {
+      role: "user",
+      modelID: null,
+      providerID: null,
+      cost: 0,
+      tokens: { input: 0, output: 0 },
+    })
+
+    const rows = fetchRawRows(setup.dbPath, REFERENCE - 1, REFERENCE + 86_400_000)
+    expect(rows).toHaveLength(0)
+  })
+
+  it("multiple messages return correct count and ASC order by time_created", () => {
+    const t1 = REFERENCE // Jul 6, 12:00
+    const t2 = REFERENCE + 3600_000 // Jul 6, 13:00
+    const t3 = REFERENCE + 7200_000 // Jul 6, 14:00
+
+    // Insert out of order
+    insertMessage(setup.dbPath, t3, {
+      role: "assistant", modelID: "gpt-4", providerID: "copilot",
+      cost: 0.05, tokens: { input: 100, output: 50 },
+    })
+    insertMessage(setup.dbPath, t1, {
+      role: "assistant", modelID: "gpt-3.5", providerID: "copilot",
+      cost: 0.01, tokens: { input: 50, output: 25 },
+    })
+    insertMessage(setup.dbPath, t2, {
+      role: "assistant", modelID: "claude-3", providerID: "anthropic",
+      cost: 0.03, tokens: { input: 200, output: 100 },
+    })
+
+    const rows = fetchRawRows(setup.dbPath, REFERENCE - 1, REFERENCE + 86_400_000)
+    expect(rows).toHaveLength(3)
+
+    // Verify ASC order by time_created
+    for (let i = 1; i < rows.length; i++) {
+      expect(rows[i].time_created).toBeGreaterThanOrEqual(rows[i - 1].time_created)
+    }
+  })
+
+  it("returns correct token/cost values matching inserted data", () => {
+    insertMessage(setup.dbPath, REFERENCE, {
+      role: "assistant", modelID: "gpt-4", providerID: "copilot",
+      cost: 0.15, tokens: { input: 5000, output: 3000 },
+    })
+    insertMessage(setup.dbPath, REFERENCE + 1000, {
+      role: "assistant", modelID: "claude-3", providerID: "anthropic",
+      cost: 0.08, tokens: { input: 2000, output: 1000 },
+    })
+
+    const rows = fetchRawRows(setup.dbPath, REFERENCE - 1, REFERENCE + 86_400_000)
+    expect(rows).toHaveLength(2)
+
+    // Flat rows ordered by time_created ASC — first copilot, then anthropic
+    expect(rows[0].model_id).toBe("gpt-4")
+    expect(rows[0].provider_id).toBe("copilot")
+    expect(rows[0].input_tokens).toBe(5000)
+    expect(rows[0].output_tokens).toBe(3000)
+    expect(rows[0].cost).toBeCloseTo(0.15, 6)
+
+    expect(rows[1].model_id).toBe("claude-3")
+    expect(rows[1].provider_id).toBe("anthropic")
+    expect(rows[1].input_tokens).toBe(2000)
+    expect(rows[1].output_tokens).toBe(1000)
+    expect(rows[1].cost).toBeCloseTo(0.08, 6)
+  })
+
+  it("handles null model_id/provider_id gracefully", () => {
+    insertMessage(setup.dbPath, REFERENCE, {
+      role: "assistant", modelID: null, providerID: null,
+      cost: 0.05, tokens: { input: 100, output: 50 },
+    })
+
+    const rows = fetchRawRows(setup.dbPath, REFERENCE - 1, REFERENCE + 86_400_000)
+    expect(Array.isArray(rows)).toBe(true)
+    // null modelID/providerID rows should be filtered out or handled gracefully
+    const nullRows = rows.filter((r: RawUsageRow) => r.model_id === null || r.provider_id === null)
+    // They may be included with null values depending on implementation
+    expect(rows.length).toBeGreaterThanOrEqual(0)
+  })
+
+  it("DB file doesn't exist → returns error object", () => {
+    const result = fetchRawRows("/nonexistent/path/to/db.db", 0, 1000)
+    expect(result).toHaveProperty("error")
+    expect(typeof result.error).toBe("string")
+    expect(result.error.length).toBeGreaterThan(0)
+  })
+
+  it("messages exactly at boundary (startMs) are included", () => {
+    insertMessage(setup.dbPath, REFERENCE, {
+      role: "assistant", modelID: "gpt-4", providerID: "copilot",
+      cost: 0.05, tokens: { input: 100, output: 50 },
+    })
+
+    // startMs = REFERENCE exactly — message should be included
+    const rows = fetchRawRows(setup.dbPath, REFERENCE, REFERENCE + 86_400_000)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].input_tokens).toBe(100)
+  })
+
+  it("messages exactly at boundary (endMs) are excluded", () => {
+    insertMessage(setup.dbPath, REFERENCE + 86_400_000, {
+      role: "assistant", modelID: "gpt-4", providerID: "copilot",
+      cost: 0.05, tokens: { input: 100, output: 50 },
+    })
+
+    // endMs = REFERENCE + 86400000 — message at exactly endMs should be excluded
+    const rows = fetchRawRows(setup.dbPath, REFERENCE, REFERENCE + 86_400_000)
+    expect(rows).toHaveLength(0)
+  })
+})

--- a/.config/opencode/plugins/model-usage/db.ts
+++ b/.config/opencode/plugins/model-usage/db.ts
@@ -63,6 +63,55 @@ export function queryUsage(dbPath: string, startMs: number, endMs: number): Usag
   }
 }
 
+export interface RawUsageRow {
+  time_created: number
+  model_id: string | null
+  provider_id: string | null
+  cost: number
+  input_tokens: number
+  output_tokens: number
+}
+
+export function fetchRawRows(dbPath: string, startMs: number, endMs: number): RawUsageRow[] | { error: string } {
+  let db: Database | null = null
+  try {
+    db = new Database(dbPath, { readonly: true })
+
+    const rows = db
+      .query(
+        `SELECT 
+           time_created,
+           json_extract(data, '$.modelID') AS model_id,
+           json_extract(data, '$.providerID') AS provider_id,
+           CAST(json_extract(data, '$.cost') AS REAL) AS cost,
+           CAST(json_extract(data, '$.tokens.input') AS INTEGER) AS input_tokens,
+           CAST(json_extract(data, '$.tokens.output') AS INTEGER) AS output_tokens
+         FROM message
+         WHERE json_extract(data, '$.role') = 'assistant'
+           AND time_created >= ?
+           AND time_created < ?
+         ORDER BY time_created ASC`,
+      )
+      .all(startMs, endMs) as RawUsageRow[]
+
+    db.close()
+    db = null
+
+    return (rows ?? []).map((r: RawUsageRow) => ({
+      time_created: r.time_created,
+      model_id: r.model_id ?? null,
+      provider_id: r.provider_id ?? null,
+      cost: r.cost ?? 0,
+      input_tokens: r.input_tokens ?? 0,
+      output_tokens: r.output_tokens ?? 0,
+    }))
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : String(err) }
+  } finally {
+    try { db?.close() } catch { /* ignore */ }
+  }
+}
+
 export function getEarliestUsageDate(dbPath: string): number | null {
   let db: Database | null = null
   try {

--- a/.config/opencode/plugins/model-usage/helpers/dates.test.ts
+++ b/.config/opencode/plugins/model-usage/helpers/dates.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "bun:test"
+import { getWeekMonday, getWeekInfo } from "./dates"
+import { formatPercentDiff } from "./format"
+
+// ─── getWeekMonday ─────────────────────────────────────────────────────────────
+
+describe("getWeekMonday", () => {
+  it("a known Monday returns itself", () => {
+    // Jul 6 2026 is a Monday
+    const d = new Date(Date.UTC(2026, 6, 6))
+    const monday = getWeekMonday(d)
+    const expected = Date.UTC(2026, 6, 6)
+    expect(monday.getTime()).toBe(expected)
+  })
+
+  it("a Tuesday returns the previous Monday", () => {
+    // Jul 7 2026 is a Tuesday → Monday Jul 6 2026
+    const d = new Date(Date.UTC(2026, 6, 7))
+    const monday = getWeekMonday(d)
+    expect(monday.getTime()).toBe(Date.UTC(2026, 6, 6))
+  })
+
+  it("a Sunday returns the previous Monday (same week)", () => {
+    // Jul 12 2026 is a Sunday → Monday Jul 6 2026
+    const d = new Date(Date.UTC(2026, 6, 12))
+    const monday = getWeekMonday(d)
+    expect(monday.getTime()).toBe(Date.UTC(2026, 6, 6))
+  })
+
+  it("month boundary: Jul 1 2026 (Wednesday) → Jun 29 2026 (Monday)", () => {
+    // Jul 1 2026 is a Wednesday
+    const d = new Date(Date.UTC(2026, 6, 1))
+    const monday = getWeekMonday(d)
+    expect(monday.getTime()).toBe(Date.UTC(2026, 5, 29))
+  })
+
+  it("year boundary: Jan 1 2026 (Thursday) → Dec 29 2025 (Monday)", () => {
+    // Jan 1 2026 is a Thursday
+    const d = new Date(Date.UTC(2026, 0, 1))
+    const monday = getWeekMonday(d)
+    expect(monday.getTime()).toBe(Date.UTC(2025, 11, 29))
+  })
+
+  it("multiple dates in the same week return the same Monday", () => {
+    // Jul 6 (Mon), Jul 8 (Wed), Jul 12 (Sun) all → Jul 6
+    const mon = getWeekMonday(new Date(Date.UTC(2026, 6, 6)))
+    const wed = getWeekMonday(new Date(Date.UTC(2026, 6, 8)))
+    const sun = getWeekMonday(new Date(Date.UTC(2026, 6, 12)))
+    expect(wed.getTime()).toBe(mon.getTime())
+    expect(sun.getTime()).toBe(mon.getTime())
+  })
+
+  it("edge case: date at exactly 00:00 UTC", () => {
+    // Jul 6 2026 00:00:00.000 UTC is a Monday
+    const d = new Date(Date.UTC(2026, 6, 6, 0, 0, 0, 0))
+    const monday = getWeekMonday(d)
+    expect(monday.getTime()).toBe(Date.UTC(2026, 6, 6))
+  })
+})
+
+// ─── getWeekInfo ───────────────────────────────────────────────────────────────
+
+describe("getWeekInfo", () => {
+  it("returns correct startMs (Monday 00:00 UTC)", () => {
+    // Jul 8 2026 (Wed) → week starts Jul 6 (Mon)
+    const info = getWeekInfo(new Date(Date.UTC(2026, 6, 8)))
+    expect(info.startMs).toBe(Date.UTC(2026, 6, 6))
+  })
+
+  it("returns correct endMs (startMs + 7 days)", () => {
+    const info = getWeekInfo(new Date(Date.UTC(2026, 6, 8)))
+    expect(info.endMs).toBe(Date.UTC(2026, 6, 13))
+  })
+
+  it('label format: "Jul 6 – Jul 12" for a July week', () => {
+    // Jul 6 (Mon) → Jul 12 (Sun)
+    const info = getWeekInfo(new Date(Date.UTC(2026, 6, 6)))
+    expect(info.label).toBe("Jul 6 – Jul 12")
+  })
+
+  it('cross-month week label: "Jun 29 – Jul 5" when week straddles months', () => {
+    // Jun 29 (Mon) → Jul 5 (Sun)
+    const info = getWeekInfo(new Date(Date.UTC(2026, 5, 29)))
+    expect(info.label).toBe("Jun 29 – Jul 5")
+  })
+
+  it("current date returns the current week's info", () => {
+    const now = new Date()
+    const info = getWeekInfo(now)
+    // Should be a valid week: 7 days span, start <= now < end
+    expect(info.startMs).toBeLessThanOrEqual(now.getTime())
+    expect(info.endMs).toBeGreaterThan(now.getTime())
+    expect(info.endMs - info.startMs).toBe(7 * 24 * 60 * 60 * 1000)
+    expect(typeof info.label).toBe("string")
+    expect(info.label.length).toBeGreaterThan(0)
+  })
+})
+
+// ─── formatPercentDiff ─────────────────────────────────────────────────────────
+
+describe("formatPercentDiff", () => {
+  it("current > previous: shows ▲ with positive percent", () => {
+    expect(formatPercentDiff(150, 100)).toEqual({ arrow: "▲", text: "+50%" })
+  })
+
+  it("current < previous: shows ▼ with negative percent", () => {
+    expect(formatPercentDiff(50, 100)).toEqual({ arrow: "▼", text: "-50%" })
+  })
+
+  it("no change: shows — for both arrow and text", () => {
+    expect(formatPercentDiff(100, 100)).toEqual({ arrow: "—", text: "—" })
+  })
+
+  it("previous is null: shows — for both arrow and text", () => {
+    expect(formatPercentDiff(100, null)).toEqual({ arrow: "—", text: "—" })
+  })
+
+  it("previous is 0: shows — (avoid division by zero)", () => {
+    expect(formatPercentDiff(100, 0)).toEqual({ arrow: "—", text: "—" })
+  })
+
+  it("large increase: current=1000, previous=10 → +9900%", () => {
+    expect(formatPercentDiff(1000, 10)).toEqual({ arrow: "▲", text: "+9900%" })
+  })
+
+  it("very small decrease: current=99, previous=100 → -1%", () => {
+    expect(formatPercentDiff(99, 100)).toEqual({ arrow: "▼", text: "-1%" })
+  })
+
+  it("current=0, previous=100 → -100%", () => {
+    expect(formatPercentDiff(0, 100)).toEqual({ arrow: "▼", text: "-100%" })
+  })
+})

--- a/.config/opencode/plugins/model-usage/helpers/dates.ts
+++ b/.config/opencode/plugins/model-usage/helpers/dates.ts
@@ -1,3 +1,5 @@
+const MS_PER_DAY = 86_400_000
+
 export function getMonthInfo(year?: number, month?: number): { startMs: number; endMs: number; label: string } {
   const now = new Date()
   const y = year ?? now.getUTCFullYear()
@@ -12,4 +14,26 @@ export function isCurrentMonth(startMs: number): boolean {
   const now = new Date()
   const currentStart = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)
   return startMs === currentStart
+}
+
+export function getWeekMonday(date: Date): Date {
+  const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()))
+  const day = d.getUTCDay()
+  // ISO week: Monday is start. getUTCDay(): 0=Sun, 1=Mon...6=Sat
+  const diff = day === 0 ? 6 : day - 1
+  d.setUTCDate(d.getUTCDate() - diff)
+  d.setUTCHours(0, 0, 0, 0)
+  return d
+}
+
+export function getWeekInfo(date: Date): { startMs: number; endMs: number; label: string } {
+  const monday = getWeekMonday(date)
+  const startMs = monday.getTime()
+  const endMs = startMs + 7 * MS_PER_DAY
+
+  const startLabel = monday.toLocaleString("en-US", { month: "short", day: "numeric", timeZone: "UTC" })
+  const sunday = new Date(endMs - 1)
+  const endLabel = sunday.toLocaleString("en-US", { month: "short", day: "numeric", timeZone: "UTC" })
+
+  return { startMs, endMs, label: `${startLabel} – ${endLabel}` }
 }

--- a/.config/opencode/plugins/model-usage/helpers/format.ts
+++ b/.config/opencode/plugins/model-usage/helpers/format.ts
@@ -48,3 +48,17 @@ export function truncateLabel(label: string, maxLen: number = 26): string {
   if (label.length <= maxLen) return label.padEnd(maxLen)
   return label.slice(0, maxLen - 1) + "\u2026"
 }
+
+export function formatPercentDiff(current: number, previous: number | null): { arrow: string; text: string } {
+  if (previous == null || previous === 0) {
+    return { arrow: "\u2014", text: "\u2014" }
+  }
+  const diff = ((current - previous) / previous) * 100
+  if (diff > 0) {
+    return { arrow: "\u25b2", text: `+${Math.round(diff)}%` }
+  }
+  if (diff < 0) {
+    return { arrow: "\u25bc", text: `${Math.round(diff)}%` }
+  }
+  return { arrow: "\u2014", text: "\u2014" }
+}

--- a/.config/opencode/plugins/model-usage/helpers/weekly.test.ts
+++ b/.config/opencode/plugins/model-usage/helpers/weekly.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Weekly.test.ts — day/week bucketing logic
+ *
+ * These tests verify pure bucketing functions (no DB needed) that group raw
+ * usage rows into day and week buckets. The functions are defined inline here
+ * as the specification for the bucketing logic that will be used by command.tsx.
+ *
+ * The RawUsageRow type matches the shape returned by fetchRawRows(db.ts) for
+ * individual assistant messages within a time range.
+ */
+
+import { describe, expect, it } from "bun:test"
+
+// ─── Types ─────────────────────────────────────────────────────────────────────
+
+interface RawUsageRow {
+  time_created: number
+  model_id: string | null
+  provider_id: string | null
+  total_cost: number
+  total_input: number
+  total_output: number
+}
+
+interface DayBucket {
+  /** UTC ms at start of the day (00:00:00.000) */
+  dayMs: number
+  totalInput: number
+  totalOutput: number
+  totalCost: number
+  count: number
+}
+
+interface WeekBucket {
+  /** UTC ms at start of the Monday of this week (00:00:00.000) */
+  startMs: number
+  label: string
+  totalInput: number
+  totalOutput: number
+  totalCost: number
+  days: DayBucket[]
+}
+
+// ─── Helpers (inlined — matches what command.tsx will use) ─────────────────────
+
+function getUTCDayStart(ts: number): number {
+  const d = new Date(ts)
+  return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate())
+}
+
+function getWeekMonday(ts: number): number {
+  const d = new Date(ts)
+  const day = d.getUTCDay() // 0=Sun, 1=Mon, ..., 6=Sat
+  // Days since Monday: if Sunday (0), go back 6 days; otherwise go back (day - 1)
+  const offset = day === 0 ? 6 : day - 1
+  const monday = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() - offset))
+  return Date.UTC(monday.getUTCFullYear(), monday.getUTCMonth(), monday.getUTCDate())
+}
+
+function formatWeekLabel(startMs: number): string {
+  const start = new Date(startMs)
+  const end = new Date(startMs + 6 * 24 * 60 * 60 * 1000)
+  const opts: Intl.DateTimeFormatOptions = { month: "short", day: "numeric", timeZone: "UTC" }
+  return `${start.toLocaleDateString("en-US", opts)} – ${end.toLocaleDateString("en-US", opts)}`
+}
+
+function bucketByDay(rows: RawUsageRow[]): DayBucket[] {
+  const map = new Map<number, DayBucket>()
+
+  for (const row of rows) {
+    const dayMs = getUTCDayStart(row.time_created)
+    const existing = map.get(dayMs)
+    if (existing) {
+      existing.totalInput += Math.max(0, row.total_input)
+      existing.totalOutput += Math.max(0, row.total_output)
+      existing.totalCost += Math.max(0, row.total_cost)
+      existing.count++
+    } else {
+      map.set(dayMs, {
+        dayMs,
+        totalInput: Math.max(0, row.total_input),
+        totalOutput: Math.max(0, row.total_output),
+        totalCost: Math.max(0, row.total_cost),
+        count: 1,
+      })
+    }
+  }
+
+  return Array.from(map.values()).sort((a, b) => a.dayMs - b.dayMs)
+}
+
+function bucketByWeek(rows: RawUsageRow[]): WeekBucket[] {
+  const days = bucketByDay(rows)
+  const map = new Map<number, DayBucket[]>()
+
+  for (const day of days) {
+    const startMs = getWeekMonday(day.dayMs)
+    const existing = map.get(startMs)
+    if (existing) {
+      existing.push(day)
+    } else {
+      map.set(startMs, [day])
+    }
+  }
+
+  return Array.from(map.entries())
+    .sort(([a], [b]) => a - b)
+    .map(([startMs, dayBuckets]) => {
+      const totalInput = dayBuckets.reduce((s, d) => s + d.totalInput, 0)
+      const totalOutput = dayBuckets.reduce((s, d) => s + d.totalOutput, 0)
+      const totalCost = dayBuckets.reduce((s, d) => s + d.totalCost, 0)
+      return {
+        startMs,
+        label: formatWeekLabel(startMs),
+        totalInput,
+        totalOutput,
+        totalCost,
+        days: dayBuckets,
+      }
+    })
+}
+
+// ─── Tests: bucketByDay ────────────────────────────────────────────────────────
+
+describe("bucketByDay", () => {
+  const REFERENCE = Date.UTC(2026, 6, 6, 12, 0, 0) // Jul 6 2026 12:00 UTC (Mon)
+
+  it("single message produces 1 day bucket with correct totals", () => {
+    const rows: RawUsageRow[] = [
+      { time_created: REFERENCE, model_id: "gpt-4", provider_id: "copilot", total_cost: 0.05, total_input: 100, total_output: 50 },
+    ]
+    const result = bucketByDay(rows)
+    expect(result).toHaveLength(1)
+    expect(result[0].dayMs).toBe(Date.UTC(2026, 6, 6))
+    expect(result[0].totalInput).toBe(100)
+    expect(result[0].totalOutput).toBe(50)
+    expect(result[0].totalCost).toBeCloseTo(0.05, 6)
+    expect(result[0].count).toBe(1)
+  })
+
+  it("multiple messages in same day are aggregated into 1 day bucket", () => {
+    const rows: RawUsageRow[] = [
+      { time_created: REFERENCE, model_id: "gpt-4", provider_id: "copilot", total_cost: 0.05, total_input: 100, total_output: 50 },
+      { time_created: REFERENCE + 3600_000, model_id: "claude-3", provider_id: "anthropic", total_cost: 0.03, total_input: 200, total_output: 100 },
+    ]
+    const result = bucketByDay(rows)
+    expect(result).toHaveLength(1)
+    expect(result[0].totalInput).toBe(300)
+    expect(result[0].totalOutput).toBe(150)
+    expect(result[0].totalCost).toBeCloseTo(0.08, 6)
+    expect(result[0].count).toBe(2)
+  })
+
+  it("messages across 3 days produce 3 day buckets", () => {
+    const day1 = Date.UTC(2026, 6, 6, 10, 0, 0) // Mon Jul 6
+    const day2 = Date.UTC(2026, 6, 7, 10, 0, 0) // Tue Jul 7
+    const day3 = Date.UTC(2026, 6, 8, 10, 0, 0) // Wed Jul 8
+
+    const rows: RawUsageRow[] = [
+      { time_created: day1, model_id: "gpt-4", provider_id: "copilot", total_cost: 0.05, total_input: 100, total_output: 50 },
+      { time_created: day2, model_id: "claude-3", provider_id: "anthropic", total_cost: 0.03, total_input: 200, total_output: 100 },
+      { time_created: day3, model_id: "gpt-4", provider_id: "copilot", total_cost: 0.07, total_input: 300, total_output: 150 },
+    ]
+    const result = bucketByDay(rows)
+    expect(result).toHaveLength(3)
+    expect(result[0].count).toBe(1)
+    expect(result[1].count).toBe(1)
+    expect(result[2].count).toBe(1)
+    // Verify ascending order
+    expect(result[0].dayMs).toBeLessThan(result[1].dayMs)
+    expect(result[1].dayMs).toBeLessThan(result[2].dayMs)
+  })
+})
+
+// ─── Tests: bucketByWeek ───────────────────────────────────────────────────────
+
+describe("bucketByWeek", () => {
+  it("messages across 2 ISO weeks produce 2 week buckets", () => {
+    // Week 1: Mon Jul 6 – Sun Jul 12
+    // Week 2: Mon Jul 13 – Sun Jul 19
+    const week1 = Date.UTC(2026, 6, 8, 12, 0, 0) // Wed Jul 8 (week 1)
+    const week2 = Date.UTC(2026, 6, 15, 12, 0, 0) // Wed Jul 15 (week 2)
+
+    const rows: RawUsageRow[] = [
+      { time_created: week1, model_id: "gpt-4", provider_id: "copilot", total_cost: 0.05, total_input: 100, total_output: 50 },
+      { time_created: week2, model_id: "claude-3", provider_id: "anthropic", total_cost: 0.03, total_input: 200, total_output: 100 },
+    ]
+    const result = bucketByWeek(rows)
+    expect(result).toHaveLength(2)
+    expect(result[0].startMs).toBe(Date.UTC(2026, 6, 6)) // Jul 6 Mon
+    expect(result[1].startMs).toBe(Date.UTC(2026, 6, 13)) // Jul 13 Mon
+  })
+
+  it('cross-month week: messages on Jun 29 (Mon) and Jul 5 (Sun) → 1 week bucket "Jun 29 – Jul 5"', () => {
+    const jun29 = Date.UTC(2026, 5, 29, 10, 0, 0) // Mon Jun 29
+    const jul5 = Date.UTC(2026, 6, 5, 14, 0, 0) // Sun Jul 5
+
+    const rows: RawUsageRow[] = [
+      { time_created: jun29, model_id: "gpt-4", provider_id: "copilot", total_cost: 0.05, total_input: 100, total_output: 50 },
+      { time_created: jul5, model_id: "claude-3", provider_id: "anthropic", total_cost: 0.03, total_input: 200, total_output: 100 },
+    ]
+    const result = bucketByWeek(rows)
+    expect(result).toHaveLength(1)
+    expect(result[0].startMs).toBe(Date.UTC(2026, 5, 29)) // Jun 29 Mon
+    expect(result[0].label).toBe("Jun 29 – Jul 5")
+    expect(result[0].days).toHaveLength(2)
+    expect(result[0].totalInput).toBe(300)
+    expect(result[0].totalOutput).toBe(150)
+    expect(result[0].totalCost).toBeCloseTo(0.08, 6)
+  })
+
+  it("verify week Monday ownership: a message on Jul 5 buckets into the week starting Jun 29", () => {
+    // Jul 5 2026 is a Sunday (day 0)
+    const jul5 = Date.UTC(2026, 6, 5, 12, 0, 0)
+    const rows: RawUsageRow[] = [
+      { time_created: jul5, model_id: "gpt-4", provider_id: "copilot", total_cost: 0.05, total_input: 100, total_output: 50 },
+    ]
+    const result = bucketByWeek(rows)
+    expect(result).toHaveLength(1)
+    // Sunday belongs to the week that started on the previous Monday (Jun 29)
+    expect(result[0].startMs).toBe(Date.UTC(2026, 5, 29))
+  })
+
+  it("verify cost aggregation across days and weeks", () => {
+    // 3 messages over 2 weeks with different costs
+    const rows: RawUsageRow[] = [
+      { time_created: Date.UTC(2026, 6, 6, 10, 0, 0), model_id: "gpt-4", provider_id: "copilot", total_cost: 0.10, total_input: 500, total_output: 250 },
+      { time_created: Date.UTC(2026, 6, 7, 10, 0, 0), model_id: "claude-3", provider_id: "anthropic", total_cost: 0.05, total_input: 200, total_output: 100 },
+      { time_created: Date.UTC(2026, 6, 14, 10, 0, 0), model_id: "gpt-4", provider_id: "copilot", total_cost: 0.20, total_input: 1000, total_output: 500 },
+    ]
+
+    const weeks = bucketByWeek(rows)
+    expect(weeks).toHaveLength(2)
+
+    // Week 1 (Jul 6 - Jul 12): 2 messages
+    expect(weeks[0].totalInput).toBe(700) // 500 + 200
+    expect(weeks[0].totalOutput).toBe(350) // 250 + 100
+    expect(weeks[0].totalCost).toBeCloseTo(0.15, 6) // 0.10 + 0.05
+    expect(weeks[0].days).toHaveLength(2)
+
+    // Week 2 (Jul 13 - Jul 19): 1 message
+    expect(weeks[1].totalInput).toBe(1000)
+    expect(weeks[1].totalOutput).toBe(500)
+    expect(weeks[1].totalCost).toBeCloseTo(0.20, 6)
+    expect(weeks[1].days).toHaveLength(1)
+  })
+
+  it("empty raw rows produce empty buckets", () => {
+    const result = bucketByWeek([])
+    expect(result).toEqual([])
+  })
+
+  it("empty raw rows produce empty day buckets", () => {
+    const result = bucketByDay([])
+    expect(result).toEqual([])
+  })
+})


### PR DESCRIPTION
Closes #31

## 📋 Changelist Summary
Added `m` key toggle to cycle through monthly → weekly → daily views in the `/usage` dialog.

## 💬 Description
- **ISO Monday–Sunday** week definition with cross-month boundary handling
- **Same per-model breakdown** rendered in all three modes (just different time windows)
- **Comparison arrows** (`▲ +XX%` / `▼ -XX%` / `—`) on the Total line vs previous period
- **Version 2 hierarchical cache** with per-model breakdown stored at month, week, and day levels
- **In-memory cache + background prefetch** for instant adjacent navigation
- **60s TTL freshness** check for the current period with `r` force-reload
- **3 new test files**: `db.test.ts` (10 tests), `dates.test.ts` (20 tests), `weekly.test.ts` (9 tests)
- **4 source files modified**: `command.tsx`, `db.ts`, `helpers/dates.ts`, `helpers/format.ts`

> ⚠️ **Auto-generated description.** This PR was generated by an AI agent and may contain inaccuracies or be incomplete. Please review and correct it before merging.