### PR TITLE
Added dual Kotlin LSP support with JetBrains toggle

### DIFF
--- a/.config/nvim/README.md
+++ b/.config/nvim/README.md
@@ -4,7 +4,7 @@ Complete LazyVim configuration with Android/Kotlin development support.
 
 ## Features
 
-- **Kotlin & Java LSP** — autocomplete, goto definition, refactoring, hover docs
+- **Kotlin & Java LSP** — dual LSP support (fwcd default, JetBrains opt-in), autocomplete, goto definition, refactoring, hover docs
 - **Android Development** — SDK detection, XML layout support
 - **Auto-formatting** — ktlint for Kotlin, google-java-format for Java (on save)
 - **Debugging** — Kotlin debugger with attach-to-process support
@@ -17,6 +17,7 @@ Complete LazyVim configuration with Android/Kotlin development support.
 | Shortcut | Action |
 |----------|--------|
 | `<leader>cl` | Check LSP health (`:checkhealth lsp`) |
+| `<leader>lk` | Kotlin actions prefix (JetBrains LSP only) — `a` (code actions), `q` (quick fix), `o` (organize imports), `f` (format) |
 
 ### Commands
 
@@ -79,6 +80,13 @@ This config provides full IDE support for Android/Kotlin development.
 - `ANDROID_SDK_ROOT` — Android SDK path (auto-detected if not set)
 - `GRADLE_JVM_TARGET` — JVM target version (auto-detected from project)
 - `GRADLE_CACHE` — enable/disable Gradle caching (default: `true`)
+- `KOTLIN_LSP` — set to `jetbrains` to use JetBrains kotlin-lsp instead of fwcd (default: unset)
+
+### Visual Indicators
+
+When editing a Kotlin file:
+- **Statusline** shows `Kotlin-LSP` (blue) for fwcd or `Kotlin-LSP (JetBrains)` (orange) for JetBrains
+- **Notification** appears on LSP attach identifying the active server
 
 ### Optional Extras
 
@@ -90,15 +98,51 @@ The file `lua/plugins/android-extras.lua` contains disabled-by-default plugins f
 
 Uncomment the sections you want in that file to enable them.
 
-## Troubleshooting
+## Dual Kotlin LSP Support
 
-### Kotlin LSP not working
+This config supports two Kotlin language servers (Zed-style):
+
+| Server | Default | Scope | Command |
+|--------|---------|-------|---------|
+| **kotlin-language-server** ([fwcd](https://github.com/fwcd/kotlin-language-server)) | ✅ Yes | Community | `:MasonInstall kotlin-language-server` |
+| **kotlin-lsp** ([JetBrains](https://github.com/Kotlin/kotlin-lsp)) | ❌ Opt-in | Official (pre-alpha) | `:MasonInstall kotlin-lsp` |
+
+### Switching to JetBrains kotlin-lsp
+
+Set the env var when starting Neovim:
+
+```bash
+KOTLIN_LSP=jetbrains nvim
+```
+
+Or set globally in your shell config (`~/.zshrc`):
+
+```bash
+export KOTLIN_LSP=jetbrains
+```
+
+Or set it in your `init.lua` / `config.lua`:
+
+```lua
+vim.g.kotlin_lsp = "jetbrains"
+```
+
+When using JetBrains kotlin-lsp, the plugin also enables:
+- **Inlay hints** — type hints, parameter names
+- **Code actions** — `:KotlinCodeActions`, `:KotlinQuickFix`, `:KotlinOrganizeImports`
+- **File templates** — new-file prompts with template interpolation
+- **Per-project config** — `.kotlin-lsp.lua` in project root
+
+### Troubleshooting
+
+#### Kotlin LSP not working
 
 - Check LSP health: `<leader>cl`
-- Verify kotlin-language-server is installed: `:Mason`
+- Verify the active server is installed: `:Mason`
 - Check logs: `:LspLog`
 
-### Version compatibility
+#### Version compatibility
 
 - kotlin-language-server (fwcd) supports Kotlin ≤ 2.2.x
-- For Kotlin 2.3.0+, consider switching to official `Kotlin/kotlin-lsp`
+- JetBrains kotlin-lsp is recommended for Kotlin 2.3.0+
+- kotlin-lsp bundles its own JRE (v261+) — no JDK installation required

--- a/.config/nvim/README.md
+++ b/.config/nvim/README.md
@@ -85,7 +85,7 @@ This config provides full IDE support for Android/Kotlin development.
 ### Visual Indicators
 
 When editing a Kotlin file:
-- **Statusline** shows `Kotlin-LSP` (blue) for fwcd or `Kotlin-LSP (JetBrains)` (orange) for JetBrains
+- **Statusline** shows `Kotlin-LSP` (blue) for fwcd or `Kotlin-LSP (JetBrains)` (purple) for JetBrains
 - **Notification** appears on LSP attach identifying the active server
 
 ### Optional Extras

--- a/.config/nvim/lua/plugins/android.lua
+++ b/.config/nvim/lua/plugins/android.lua
@@ -128,7 +128,7 @@ return {
           return {}
         end
         local jetbrains = vim.env.KOTLIN_LSP == "jetbrains" or vim.g.kotlin_lsp == "jetbrains"
-        return jetbrains and { fg = "#FF5722" } or { fg = "#2196F3" }
+        return jetbrains and { fg = "#BB86FC" } or { fg = "#2196F3" }
       end
 
       opts.sections = opts.sections or {}

--- a/.config/nvim/lua/plugins/android.lua
+++ b/.config/nvim/lua/plugins/android.lua
@@ -1,6 +1,6 @@
 -- Android Development Configuration
 -- Adds Android-specific enhancements on top of the Kotlin/Gradle setup.
--- Does NOT touch LSP classpath — kotlin-language-server handles its own Gradle sync.
+-- Does NOT touch LSP classpath — both kotlin-language-server and kotlin-lsp handle their own Gradle sync.
 
 local gradle = require("utils.gradle")
 local android = require("utils.android")
@@ -115,8 +115,32 @@ return {
         return { fg = "#2196F3" }
       end
 
+      local function kotlin_lsp_indicator()
+        if vim.bo.filetype ~= "kotlin" then
+          return ""
+        end
+        local jetbrains = vim.env.KOTLIN_LSP == "jetbrains" or vim.g.kotlin_lsp == "jetbrains"
+        return jetbrains and "Kotlin-LSP (JetBrains)" or "Kotlin-LSP"
+      end
+
+      local function kotlin_lsp_color()
+        if vim.bo.filetype ~= "kotlin" then
+          return {}
+        end
+        local jetbrains = vim.env.KOTLIN_LSP == "jetbrains" or vim.g.kotlin_lsp == "jetbrains"
+        return jetbrains and { fg = "#FF5722" } or { fg = "#2196F3" }
+      end
+
       opts.sections = opts.sections or {}
       opts.sections.lualine_x = opts.sections.lualine_x or {}
+
+      table.insert(opts.sections.lualine_x, 1, {
+        kotlin_lsp_indicator,
+        cond = function()
+          return vim.bo.filetype == "kotlin"
+        end,
+        color = kotlin_lsp_color,
+      })
 
       table.insert(opts.sections.lualine_x, 1, {
         gradle_indicator,

--- a/.config/nvim/lua/plugins/kotlin.lua
+++ b/.config/nvim/lua/plugins/kotlin.lua
@@ -1,29 +1,28 @@
--- Kotlin Language Server Configuration
--- Works WITH LazyVim's kotlin extra, not against it.
--- kotlin-language-server handles its own Gradle sync internally.
+local use_jetbrains = vim.env.KOTLIN_LSP == "jetbrains"
+  or vim.g.kotlin_lsp == "jetbrains"
 
-return {
-  -- ==========================================
-  -- KOTLIN FILETYPE DETECTION
-  -- ==========================================
-  {
-    "LazyVim/LazyVim",
-    init = function()
-      vim.filetype.add({
-        extension = {
-          kt = "kotlin",
-          kts = "kotlin",
-        },
-      })
-    end,
-  },
+local specs = {}
 
-  -- ==========================================
-  -- KOTLIN LANGUAGE SERVER CONFIGURATION
-  -- ==========================================
-  -- Extends LazyVim's kotlin extra via lspconfig opts.
-  -- Do NOT manually start the LSP — LazyVim handles that.
-  {
+-- ==========================================
+-- KOTLIN FILETYPE DETECTION
+-- ==========================================
+table.insert(specs, {
+  "LazyVim/LazyVim",
+  init = function()
+    vim.filetype.add({
+      extension = {
+        kt = "kotlin",
+        kts = "kotlin",
+      },
+    })
+  end,
+})
+
+-- ==========================================
+-- DEFAULT LSP: kotlin-language-server (fwcd)
+-- ==========================================
+if not use_jetbrains then
+  table.insert(specs, {
     "neovim/nvim-lspconfig",
     opts = {
       servers = {
@@ -52,24 +51,93 @@ return {
         },
       },
     },
-  },
+  })
+end
 
-  -- ==========================================
-  -- GRADLE/ANDROID INITIALIZATION
-  -- ==========================================
-  {
-    "LazyVim/LazyVim",
-    init = function()
-      vim.api.nvim_create_autocmd("User", {
-        pattern = "VeryLazy",
-        callback = function()
-          require("utils.gradle").setup()
-          require("utils.android").setup()
-        end,
+-- ==========================================
+-- OPT-IN LSP: kotlin-lsp (JetBrains)
+-- Enable with: KOTLIN_LSP=jetbrains or vim.g.kotlin_lsp = "jetbrains"
+-- ==========================================
+if use_jetbrains then
+  table.insert(specs, {
+    "neovim/nvim-lspconfig",
+    opts = {
+      servers = {
+        kotlin_language_server = { enabled = false },
+      },
+    },
+  })
+
+  table.insert(specs, {
+    "AlexandrosAlexiou/kotlin.nvim",
+    ft = { "kotlin" },
+    dependencies = {
+      "stevearc/oil.nvim",
+      "folke/trouble.nvim",
+    },
+    config = function()
+      require("kotlin").setup({
+        jvm_args = { "-Xmx4g" },
+        inlay_hints = {
+          enabled = true,
+          parameters = true,
+          types_property = true,
+          types_variable = true,
+          function_return = true,
+        },
+        folding = { enabled = true },
       })
-
-      vim.keymap.set("n", "<leader>cl", "<cmd>checkhealth lsp<cr>",
-        { desc = "Check LSP health" })
     end,
-  },
-}
+  })
+end
+
+
+
+-- ==========================================
+-- LSP ATTACH NOTIFICATION
+-- ==========================================
+table.insert(specs, {
+  "LazyVim/LazyVim",
+  init = function()
+    vim.api.nvim_create_autocmd("LspAttach", {
+      group = vim.api.nvim_create_augroup("kotlin-lsp-indicator", { clear = true }),
+      callback = function(args)
+        if vim.bo[args.buf].filetype ~= "kotlin" then
+          return
+        end
+        local client = vim.lsp.get_client_by_id(args.data.client_id)
+        if not client then
+          return
+        end
+        local name = client.name
+        local label = name == "kotlin-language-server" and "Kotlin-LSP (fwcd)"
+          or (name == "kotlin-lsp" or name == "intellij-server") and "Kotlin-LSP (JetBrains)"
+          or name
+        vim.notify(label .. " attached", vim.log.levels.INFO, {
+          title = "LSP",
+          timeout = 2000,
+        })
+      end,
+    })
+  end,
+})
+
+-- ==========================================
+-- GRADLE/ANDROID INITIALIZATION
+-- ==========================================
+table.insert(specs, {
+  "LazyVim/LazyVim",
+  init = function()
+    vim.api.nvim_create_autocmd("User", {
+      pattern = "VeryLazy",
+      callback = function()
+        require("utils.gradle").setup()
+        require("utils.android").setup()
+      end,
+    })
+
+    vim.keymap.set("n", "<leader>cl", "<cmd>checkhealth lsp<cr>", { desc = "Check LSP health" })
+  end,
+})
+
+return specs

--- a/.config/nvim/lua/plugins/kotlin.lua
+++ b/.config/nvim/lua/plugins/kotlin.lua
@@ -68,6 +68,149 @@ if use_jetbrains then
     },
   })
 
+  local function diagnose_jetbrains_workspace(phase)
+    local cache_dir = vim.fn.expand("~/Library/Caches/JetBrains/analyzer/workspaces")
+    local log_file = vim.fn.stdpath("log") .. "/kotlin-lsp-cleanup.log"
+    local timestamp = os.date("%Y-%m-%d %H:%M:%S")
+    local lines = {}
+    local function add(msg)
+      table.insert(lines, string.format("[%s] [%s] %s", timestamp, phase, msg))
+    end
+
+    add("Neovim PID: " .. vim.fn.getpid())
+
+    -- 1. Cache directory
+    if vim.fn.isdirectory(cache_dir) == 1 then
+      local workspaces = vim.fn.glob(cache_dir .. "/*", false, true)
+      add("Cache dir: " .. cache_dir .. " (" .. #workspaces .. " workspace(s))")
+
+      -- 2. LOCK files
+      if vim.fn.executable("lsof") == 1 then
+        for _, ws in ipairs(workspaces) do
+          local patterns = { ws .. "/LOCK", ws .. "/rocks/*/LOCK" }
+          for _, pat in ipairs(patterns) do
+            local locks = vim.fn.glob(pat, false, true)
+            for _, lock in ipairs(locks) do
+              local held = vim.fn.system({ "lsof", lock })
+              if vim.trim(held) == "" then
+                add("LOCK: " .. lock .. " → STALE (no holder)")
+              else
+                add("LOCK: " .. lock .. " → HELD\n" .. held)
+              end
+            end
+          end
+        end
+      else
+        add("lsof not available — skipping LOCK check")
+      end
+    else
+      add("Cache dir not found: " .. cache_dir)
+    end
+
+    -- 3. intellij-server processes
+    if vim.fn.executable("pgrep") == 1 then
+      local ps_out = vim.trim(vim.fn.system({ "pgrep", "-f", "intellij-server" }))
+      if ps_out == "" then
+        add("intellij-server processes: none")
+      else
+        local pids = vim.split(ps_out, "\n")
+        add("intellij-server processes: " .. #pids)
+        for _, pid in ipairs(pids) do
+          pid = vim.trim(pid)
+          if pid ~= "" then
+            local ppid_out = vim.trim(vim.fn.system({ "ps", "-o", "ppid=", "-p", pid }))
+            local ppid = tonumber(ppid_out)
+            local parent_cmd = ppid and vim.trim(vim.fn.system({ "ps", "-o", "comm=", "-p", ppid })) or "?"
+            local is_orphan = ppid == 1
+            local is_mine = ppid == vim.fn.getpid()
+            add("  PID " .. pid .. " PPID " .. tostring(ppid or "?")
+              .. " (" .. parent_cmd .. ") orphan=" .. tostring(is_orphan)
+              .. " mine=" .. tostring(is_mine))
+          end
+        end
+      end
+    else
+      add("pgrep not available — skipping process check")
+    end
+
+    local fd = io.open(log_file, "a")
+    if fd then
+      fd:write(table.concat(lines, "\n") .. "\n")
+      fd:close()
+    else
+      vim.notify("kotlin-lsp-cleanup: could not write to " .. log_file, vim.log.levels.WARN)
+    end
+  end
+
+  local function cleanup_jetbrains_workspace()
+    local nvim_pid = vim.fn.getpid()
+    local cache_dir = vim.fn.expand("~/Library/Caches/JetBrains/analyzer/workspaces")
+    local my_server_pids = {}
+    local my_lock_files = {}
+
+    -- 1. Find intellij-server children of this Neovim
+    if vim.fn.executable("pgrep") == 1 then
+      local children = vim.trim(vim.fn.system({ "pgrep", "-P", tostring(nvim_pid) }))
+      if children ~= "" then
+        for _, pid in ipairs(vim.split(children, "\n")) do
+          pid = vim.trim(pid)
+          if pid ~= "" then
+            local cmd = vim.trim(vim.fn.system({ "ps", "-o", "comm=", "-p", pid }))
+            if cmd:find("intellij%-server") then
+              table.insert(my_server_pids, pid)
+            end
+          end
+        end
+      end
+    end
+
+    -- 2. Find LOCK files held by our server PIDs (before killing)
+    if #my_server_pids > 0 and vim.fn.executable("lsof") == 1 then
+      for _, pid in ipairs(my_server_pids) do
+        local lsof_out = vim.fn.system({ "lsof", "-Fn", "-p", pid })
+        for line in lsof_out:gmatch("[^\r\n]+") do
+          local path = line:match("^n(.+)$")
+          if path and path:match("LOCK$") and path:find(cache_dir, 1, true) then
+            table.insert(my_lock_files, path)
+          end
+        end
+      end
+    end
+
+    -- 3. Kill our intellij-server processes
+    for _, pid in ipairs(my_server_pids) do
+      vim.fn.system({ "kill", pid })
+    end
+
+    -- 4. Remove identified LOCK files (now stale after kill)
+    for _, path in ipairs(my_lock_files) do
+      if vim.fn.filereadable(path) == 1 then
+        os.remove(path)
+      end
+    end
+
+    -- 5. Fallback: sweep for stale LOCKs (server may have died before VimLeavePre)
+    if vim.fn.isdirectory(cache_dir) == 1 and vim.fn.executable("lsof") == 1 then
+      local workspaces = vim.fn.glob(cache_dir .. "/*", false, true)
+      for _, ws in ipairs(workspaces) do
+        local locks = vim.fn.glob(ws .. "/rocks/*/LOCK", false, true)
+        for _, lock in ipairs(locks) do
+          if vim.trim(vim.fn.system({ "lsof", lock })) == "" then
+            os.remove(lock)
+            table.insert(my_lock_files, lock)
+          end
+        end
+      end
+    end
+
+    if #my_server_pids > 0 or #my_lock_files > 0 then
+      vim.notify(
+        "Kotlin-LSP (JetBrains): killed " .. #my_server_pids .. " server(s), removed " .. #my_lock_files .. " LOCK file(s)",
+        vim.log.levels.INFO
+      )
+    end
+  end
+
   table.insert(specs, {
     "AlexandrosAlexiou/kotlin.nvim",
     ft = { "kotlin" },
@@ -76,6 +219,8 @@ if use_jetbrains then
       "folke/trouble.nvim",
     },
     config = function()
+      diagnose_jetbrains_workspace("STARTUP")
+
       require("kotlin").setup({
         jvm_args = { "-Xmx4g" },
         inlay_hints = {
@@ -86,6 +231,15 @@ if use_jetbrains then
           function_return = true,
         },
         folding = { enabled = true },
+      })
+
+      local group = vim.api.nvim_create_augroup("kotlin-lsp-cleanup", { clear = true })
+      vim.api.nvim_create_autocmd("VimLeavePre", {
+        group = group,
+        callback = function()
+          diagnose_jetbrains_workspace("SHUTDOWN")
+          cleanup_jetbrains_workspace()
+        end,
       })
     end,
   })

--- a/.config/nvim/lua/plugins/kotlin.lua
+++ b/.config/nvim/lua/plugins/kotlin.lua
@@ -1,5 +1,4 @@
 local use_jetbrains = vim.env.KOTLIN_LSP == "jetbrains"
-  or vim.g.kotlin_lsp == "jetbrains"
 
 local specs = {}
 
@@ -57,6 +56,8 @@ end
 -- ==========================================
 -- OPT-IN LSP: kotlin-lsp (JetBrains)
 -- Enable with: KOTLIN_LSP=jetbrains or vim.g.kotlin_lsp = "jetbrains"
+-- Requires: brew install JetBrains/utils/kotlin-lsp
+-- Official guide: https://github.com/Kotlin/kotlin-lsp/blob/main/scripts/neovim.md
 -- ==========================================
 if use_jetbrains then
   table.insert(specs, {
@@ -68,184 +69,93 @@ if use_jetbrains then
     },
   })
 
-  local function diagnose_jetbrains_workspace(phase)
+  local function remove_stale_locks()
     local cache_dir = vim.fn.expand("~/Library/Caches/JetBrains/analyzer/workspaces")
-    local log_file = vim.fn.stdpath("log") .. "/kotlin-lsp-cleanup.log"
-    local timestamp = os.date("%Y-%m-%d %H:%M:%S")
-    local lines = {}
-    local function add(msg)
-      table.insert(lines, string.format("[%s] [%s] %s", timestamp, phase, msg))
-    end
+    if vim.fn.isdirectory(cache_dir) == 0 or vim.fn.executable("lsof") == 0 then return end
 
-    add("Neovim PID: " .. vim.fn.getpid())
-
-    -- 1. Cache directory
-    if vim.fn.isdirectory(cache_dir) == 1 then
-      local workspaces = vim.fn.glob(cache_dir .. "/*", false, true)
-      add("Cache dir: " .. cache_dir .. " (" .. #workspaces .. " workspace(s))")
-
-      -- 2. LOCK files
-      if vim.fn.executable("lsof") == 1 then
-        for _, ws in ipairs(workspaces) do
-          local patterns = { ws .. "/LOCK", ws .. "/rocks/*/LOCK" }
-          for _, pat in ipairs(patterns) do
-            local locks = vim.fn.glob(pat, false, true)
-            for _, lock in ipairs(locks) do
-              local held = vim.fn.system({ "lsof", lock })
-              if vim.trim(held) == "" then
-                add("LOCK: " .. lock .. " → STALE (no holder)")
-              else
-                add("LOCK: " .. lock .. " → HELD\n" .. held)
-              end
-            end
-          end
-        end
-      else
-        add("lsof not available — skipping LOCK check")
+    local locks = vim.fn.glob(cache_dir .. "/*/rocks/*/LOCK", false, true)
+    for _, lock in ipairs(locks) do
+      if vim.fn.filereadable(lock) == 1 and vim.trim(vim.fn.system({ "lsof", lock })) == "" then
+        os.remove(lock)
       end
-    else
-      add("Cache dir not found: " .. cache_dir)
-    end
-
-    -- 3. intellij-server processes
-    if vim.fn.executable("pgrep") == 1 then
-      local ps_out = vim.trim(vim.fn.system({ "pgrep", "-f", "intellij-server" }))
-      if ps_out == "" then
-        add("intellij-server processes: none")
-      else
-        local pids = vim.split(ps_out, "\n")
-        add("intellij-server processes: " .. #pids)
-        for _, pid in ipairs(pids) do
-          pid = vim.trim(pid)
-          if pid ~= "" then
-            local ppid_out = vim.trim(vim.fn.system({ "ps", "-o", "ppid=", "-p", pid }))
-            local ppid = tonumber(ppid_out)
-            local parent_cmd = ppid and vim.trim(vim.fn.system({ "ps", "-o", "comm=", "-p", ppid })) or "?"
-            local is_orphan = ppid == 1
-            local is_mine = ppid == vim.fn.getpid()
-            add("  PID " .. pid .. " PPID " .. tostring(ppid or "?")
-              .. " (" .. parent_cmd .. ") orphan=" .. tostring(is_orphan)
-              .. " mine=" .. tostring(is_mine))
-          end
-        end
-      end
-    else
-      add("pgrep not available — skipping process check")
-    end
-
-    local fd = io.open(log_file, "a")
-    if fd then
-      fd:write(table.concat(lines, "\n") .. "\n")
-      fd:close()
-    else
-      vim.notify("kotlin-lsp-cleanup: could not write to " .. log_file, vim.log.levels.WARN)
     end
   end
 
   local function cleanup_jetbrains_workspace()
     local nvim_pid = vim.fn.getpid()
     local cache_dir = vim.fn.expand("~/Library/Caches/JetBrains/analyzer/workspaces")
-    local my_server_pids = {}
-    local my_lock_files = {}
+    local my_pids = {}
+    local my_locks = {}
 
-    -- 1. Find intellij-server children of this Neovim
-    if vim.fn.executable("pgrep") == 1 then
-      local children = vim.trim(vim.fn.system({ "pgrep", "-P", tostring(nvim_pid) }))
-      if children ~= "" then
-        for _, pid in ipairs(vim.split(children, "\n")) do
-          pid = vim.trim(pid)
-          if pid ~= "" then
-            local cmd = vim.trim(vim.fn.system({ "ps", "-o", "comm=", "-p", pid }))
-            if cmd:find("intellij%-server") then
-              table.insert(my_server_pids, pid)
-            end
+    if vim.fn.executable("pgrep") == 0 then return end
+
+    local children = vim.trim(vim.fn.system({ "pgrep", "-P", tostring(nvim_pid) }))
+    if children ~= "" then
+      for _, pid in ipairs(vim.split(children, "\n")) do
+        pid = vim.trim(pid)
+        if pid ~= "" then
+          local cmd = vim.trim(vim.fn.system({ "ps", "-o", "comm=", "-p", pid }))
+          if cmd:find("intellij%-server") or cmd:find("java") then
+            table.insert(my_pids, pid)
           end
         end
       end
     end
 
-    -- 2. Find LOCK files held by our server PIDs (before killing)
-    if #my_server_pids > 0 and vim.fn.executable("lsof") == 1 then
-      for _, pid in ipairs(my_server_pids) do
+    if #my_pids > 0 and vim.fn.executable("lsof") == 1 then
+      for _, pid in ipairs(my_pids) do
         local lsof_out = vim.fn.system({ "lsof", "-Fn", "-p", pid })
         for line in lsof_out:gmatch("[^\r\n]+") do
           local path = line:match("^n(.+)$")
           if path and path:match("LOCK$") and path:find(cache_dir, 1, true) then
-            table.insert(my_lock_files, path)
+            table.insert(my_locks, path)
           end
         end
       end
     end
 
-    -- 3. Kill our intellij-server processes
-    for _, pid in ipairs(my_server_pids) do
+    for _, pid in ipairs(my_pids) do
       vim.fn.system({ "kill", pid })
     end
 
-    -- 4. Remove identified LOCK files (now stale after kill)
-    for _, path in ipairs(my_lock_files) do
-      if vim.fn.filereadable(path) == 1 then
-        os.remove(path)
-      end
+    for _, path in ipairs(my_locks) do
+      if vim.fn.filereadable(path) == 1 then os.remove(path) end
     end
 
-    -- 5. Fallback: sweep for stale LOCKs (server may have died before VimLeavePre)
     if vim.fn.isdirectory(cache_dir) == 1 and vim.fn.executable("lsof") == 1 then
       local workspaces = vim.fn.glob(cache_dir .. "/*", false, true)
       for _, ws in ipairs(workspaces) do
         local locks = vim.fn.glob(ws .. "/rocks/*/LOCK", false, true)
         for _, lock in ipairs(locks) do
-          if vim.trim(vim.fn.system({ "lsof", lock })) == "" then
+          if vim.fn.filereadable(lock) == 1 and vim.trim(vim.fn.system({ "lsof", lock })) == "" then
             os.remove(lock)
-            table.insert(my_lock_files, lock)
           end
         end
       end
     end
-
-    if #my_server_pids > 0 or #my_lock_files > 0 then
-      vim.notify(
-        "Kotlin-LSP (JetBrains): killed " .. #my_server_pids .. " server(s), removed " .. #my_lock_files .. " LOCK file(s)",
-        vim.log.levels.INFO
-      )
-    end
   end
 
   table.insert(specs, {
-    "AlexandrosAlexiou/kotlin.nvim",
-    ft = { "kotlin" },
-    dependencies = {
-      "stevearc/oil.nvim",
-      "folke/trouble.nvim",
-    },
-    config = function()
-      diagnose_jetbrains_workspace("STARTUP")
+    "LazyVim/LazyVim",
+    init = function()
+      remove_stale_locks()
 
-      require("kotlin").setup({
-        jvm_args = { "-Xmx4g" },
-        inlay_hints = {
-          enabled = true,
-          parameters = true,
-          types_property = true,
-          types_variable = true,
-          function_return = true,
-        },
-        folding = { enabled = true },
+      vim.lsp.config('kotlin_lsp', {
+        cmd = { 'kotlin-lsp' },
+        filetypes = { 'kotlin' },
+        single_file_support = false,
+        root_markers = { 'build.gradle', 'build.gradle.kts', 'pom.xml' },
       })
+      vim.lsp.enable('kotlin_lsp')
 
       local group = vim.api.nvim_create_augroup("kotlin-lsp-cleanup", { clear = true })
       vim.api.nvim_create_autocmd("VimLeavePre", {
         group = group,
-        callback = function()
-          diagnose_jetbrains_workspace("SHUTDOWN")
-          cleanup_jetbrains_workspace()
-        end,
+        callback = cleanup_jetbrains_workspace,
       })
     end,
   })
 end
-
-
 
 -- ==========================================
 -- LSP ATTACH NOTIFICATION

--- a/.config/nvim/lua/plugins/kotlin.lua.plugin
+++ b/.config/nvim/lua/plugins/kotlin.lua.plugin
@@ -1,0 +1,297 @@
+local use_jetbrains = vim.env.KOTLIN_LSP == "jetbrains"
+  or vim.g.kotlin_lsp == "jetbrains"
+
+local specs = {}
+
+-- ==========================================
+-- KOTLIN FILETYPE DETECTION
+-- ==========================================
+table.insert(specs, {
+  "LazyVim/LazyVim",
+  init = function()
+    vim.filetype.add({
+      extension = {
+        kt = "kotlin",
+        kts = "kotlin",
+      },
+    })
+  end,
+})
+
+-- ==========================================
+-- DEFAULT LSP: kotlin-language-server (fwcd)
+-- ==========================================
+if not use_jetbrains then
+  table.insert(specs, {
+    "neovim/nvim-lspconfig",
+    opts = {
+      servers = {
+        kotlin_language_server = {
+          init_options = {
+            storagePath = vim.fn.resolve(vim.fn.stdpath("cache") .. "/kotlin_language_server"),
+          },
+          settings = {
+            kotlin = {
+              compiler = {
+                jvm = {
+                  target = vim.env.GRADLE_JVM_TARGET or "17",
+                },
+              },
+              linting = {
+                debounceTime = 300,
+              },
+              indexing = {
+                enabled = true,
+              },
+              externalSources = {
+                autoConvertToKotlin = true,
+              },
+            },
+          },
+        },
+      },
+    },
+  })
+end
+
+-- ==========================================
+-- OPT-IN LSP: kotlin-lsp (JetBrains)
+-- Enable with: KOTLIN_LSP=jetbrains or vim.g.kotlin_lsp = "jetbrains"
+-- ==========================================
+if use_jetbrains then
+  table.insert(specs, {
+    "neovim/nvim-lspconfig",
+    opts = {
+      servers = {
+        kotlin_language_server = { enabled = false },
+      },
+    },
+  })
+
+  local function diagnose_jetbrains_workspace(phase)
+    local cache_dir = vim.fn.expand("~/Library/Caches/JetBrains/analyzer/workspaces")
+    local log_file = vim.fn.stdpath("log") .. "/kotlin-lsp-cleanup.log"
+    local timestamp = os.date("%Y-%m-%d %H:%M:%S")
+    local lines = {}
+    local function add(msg)
+      table.insert(lines, string.format("[%s] [%s] %s", timestamp, phase, msg))
+    end
+
+    add("Neovim PID: " .. vim.fn.getpid())
+
+    -- 1. Cache directory
+    if vim.fn.isdirectory(cache_dir) == 1 then
+      local workspaces = vim.fn.glob(cache_dir .. "/*", false, true)
+      add("Cache dir: " .. cache_dir .. " (" .. #workspaces .. " workspace(s))")
+
+      -- 2. LOCK files
+      if vim.fn.executable("lsof") == 1 then
+        for _, ws in ipairs(workspaces) do
+          local patterns = { ws .. "/LOCK", ws .. "/rocks/*/LOCK" }
+          for _, pat in ipairs(patterns) do
+            local locks = vim.fn.glob(pat, false, true)
+            for _, lock in ipairs(locks) do
+              local held = vim.fn.system({ "lsof", lock })
+              if vim.trim(held) == "" then
+                add("LOCK: " .. lock .. " → STALE (no holder)")
+              else
+                add("LOCK: " .. lock .. " → HELD\n" .. held)
+              end
+            end
+          end
+        end
+      else
+        add("lsof not available — skipping LOCK check")
+      end
+    else
+      add("Cache dir not found: " .. cache_dir)
+    end
+
+    -- 3. intellij-server processes
+    if vim.fn.executable("pgrep") == 1 then
+      local ps_out = vim.trim(vim.fn.system({ "pgrep", "-f", "intellij-server" }))
+      if ps_out == "" then
+        add("intellij-server processes: none")
+      else
+        local pids = vim.split(ps_out, "\n")
+        add("intellij-server processes: " .. #pids)
+        for _, pid in ipairs(pids) do
+          pid = vim.trim(pid)
+          if pid ~= "" then
+            local ppid_out = vim.trim(vim.fn.system({ "ps", "-o", "ppid=", "-p", pid }))
+            local ppid = tonumber(ppid_out)
+            local parent_cmd = ppid and vim.trim(vim.fn.system({ "ps", "-o", "comm=", "-p", ppid })) or "?"
+            local is_orphan = ppid == 1
+            local is_mine = ppid == vim.fn.getpid()
+            add("  PID " .. pid .. " PPID " .. tostring(ppid or "?")
+              .. " (" .. parent_cmd .. ") orphan=" .. tostring(is_orphan)
+              .. " mine=" .. tostring(is_mine))
+          end
+        end
+      end
+    else
+      add("pgrep not available — skipping process check")
+    end
+
+    local fd = io.open(log_file, "a")
+    if fd then
+      fd:write(table.concat(lines, "\n") .. "\n")
+      fd:close()
+    else
+      vim.notify("kotlin-lsp-cleanup: could not write to " .. log_file, vim.log.levels.WARN)
+    end
+  end
+
+  local function cleanup_jetbrains_workspace()
+    local nvim_pid = vim.fn.getpid()
+    local cache_dir = vim.fn.expand("~/Library/Caches/JetBrains/analyzer/workspaces")
+    local my_server_pids = {}
+    local my_lock_files = {}
+
+    -- 1. Find intellij-server children of this Neovim
+    if vim.fn.executable("pgrep") == 1 then
+      local children = vim.trim(vim.fn.system({ "pgrep", "-P", tostring(nvim_pid) }))
+      if children ~= "" then
+        for _, pid in ipairs(vim.split(children, "\n")) do
+          pid = vim.trim(pid)
+          if pid ~= "" then
+            local cmd = vim.trim(vim.fn.system({ "ps", "-o", "comm=", "-p", pid }))
+            if cmd:find("intellij%-server") then
+              table.insert(my_server_pids, pid)
+            end
+          end
+        end
+      end
+    end
+
+    -- 2. Find LOCK files held by our server PIDs (before killing)
+    if #my_server_pids > 0 and vim.fn.executable("lsof") == 1 then
+      for _, pid in ipairs(my_server_pids) do
+        local lsof_out = vim.fn.system({ "lsof", "-Fn", "-p", pid })
+        for line in lsof_out:gmatch("[^\r\n]+") do
+          local path = line:match("^n(.+)$")
+          if path and path:match("LOCK$") and path:find(cache_dir, 1, true) then
+            table.insert(my_lock_files, path)
+          end
+        end
+      end
+    end
+
+    -- 3. Kill our intellij-server processes
+    for _, pid in ipairs(my_server_pids) do
+      vim.fn.system({ "kill", pid })
+    end
+
+    -- 4. Remove identified LOCK files (now stale after kill)
+    for _, path in ipairs(my_lock_files) do
+      if vim.fn.filereadable(path) == 1 then
+        os.remove(path)
+      end
+    end
+
+    -- 5. Fallback: sweep for stale LOCKs (server may have died before VimLeavePre)
+    if vim.fn.isdirectory(cache_dir) == 1 and vim.fn.executable("lsof") == 1 then
+      local workspaces = vim.fn.glob(cache_dir .. "/*", false, true)
+      for _, ws in ipairs(workspaces) do
+        local locks = vim.fn.glob(ws .. "/rocks/*/LOCK", false, true)
+        for _, lock in ipairs(locks) do
+          if vim.trim(vim.fn.system({ "lsof", lock })) == "" then
+            os.remove(lock)
+            table.insert(my_lock_files, lock)
+          end
+        end
+      end
+    end
+
+    if #my_server_pids > 0 or #my_lock_files > 0 then
+      vim.notify(
+        "Kotlin-LSP (JetBrains): killed " .. #my_server_pids .. " server(s), removed " .. #my_lock_files .. " LOCK file(s)",
+        vim.log.levels.INFO
+      )
+    end
+  end
+
+  table.insert(specs, {
+    "AlexandrosAlexiou/kotlin.nvim",
+    ft = { "kotlin" },
+    dependencies = {
+      "stevearc/oil.nvim",
+      "folke/trouble.nvim",
+    },
+    config = function()
+      diagnose_jetbrains_workspace("STARTUP")
+
+      require("kotlin").setup({
+        jvm_args = { "-Xmx4g" },
+        inlay_hints = {
+          enabled = true,
+          parameters = true,
+          types_property = true,
+          types_variable = true,
+          function_return = true,
+        },
+        folding = { enabled = true },
+      })
+
+      local group = vim.api.nvim_create_augroup("kotlin-lsp-cleanup", { clear = true })
+      vim.api.nvim_create_autocmd("VimLeavePre", {
+        group = group,
+        callback = function()
+          diagnose_jetbrains_workspace("SHUTDOWN")
+          cleanup_jetbrains_workspace()
+        end,
+      })
+    end,
+  })
+end
+
+
+
+-- ==========================================
+-- LSP ATTACH NOTIFICATION
+-- ==========================================
+table.insert(specs, {
+  "LazyVim/LazyVim",
+  init = function()
+    vim.api.nvim_create_autocmd("LspAttach", {
+      group = vim.api.nvim_create_augroup("kotlin-lsp-indicator", { clear = true }),
+      callback = function(args)
+        if vim.bo[args.buf].filetype ~= "kotlin" then
+          return
+        end
+        local client = vim.lsp.get_client_by_id(args.data.client_id)
+        if not client then
+          return
+        end
+        local name = client.name
+        local label = name == "kotlin-language-server" and "Kotlin-LSP (fwcd)"
+          or (name == "kotlin-lsp" or name == "intellij-server") and "Kotlin-LSP (JetBrains)"
+          or name
+        vim.notify(label .. " attached", vim.log.levels.INFO, {
+          title = "LSP",
+          timeout = 2000,
+        })
+      end,
+    })
+  end,
+})
+
+-- ==========================================
+-- GRADLE/ANDROID INITIALIZATION
+-- ==========================================
+table.insert(specs, {
+  "LazyVim/LazyVim",
+  init = function()
+    vim.api.nvim_create_autocmd("User", {
+      pattern = "VeryLazy",
+      callback = function()
+        require("utils.gradle").setup()
+        require("utils.android").setup()
+      end,
+    })
+
+    vim.keymap.set("n", "<leader>cl", "<cmd>checkhealth lsp<cr>", { desc = "Check LSP health" })
+  end,
+})
+
+return specs

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Complete LazyVim configuration with:
   - SDK detection and statusline indicators
   - Markdown with live preview
 - **Languages:** Kotlin, Java, XML, Markdown, TOML, Groovy (Gradle)
-- **Kotlin LSP:** Dual LSP support — defaults to the community `kotlin-language-server` (fwcd). For full IntelliJ-level indexing (Kotlin 2.3.0+), switch to the official JetBrains backend with `KOTLIN_LSP=jetbrains`. The JetBrains server auto-cleans up stale RocksDB locks on shutdown to prevent "LOCK: Resource temporarily unavailable" errors.
+- **Kotlin LSP:** Dual LSP support — defaults to the community `kotlin-language-server` (fwcd). For full IntelliJ-level indexing (Kotlin 2.3.0+), switch to the official JetBrains backend with `KOTLIN_LSP=jetbrains` (requires `brew install JetBrains/utils/kotlin-lsp`). The JetBrains server auto-cleans up stale RocksDB locks on shutdown to prevent "LOCK: Resource temporarily unavailable" errors.
 
 ### AI Assistant
 - Opencode configuration with specialized agents and plugins
@@ -116,7 +116,7 @@ This config provides full IDE support for Android development with Neovim:
 **Quick Start:**
 1. Open any `.kt` or `.java` file in an Android project
 2. LSP will auto-start and provide IDE features
-3. Use `:Mason` to install missing tools if needed
+3. Use `:Mason` to install missing tools if needed (or `brew install JetBrains/utils/kotlin-lsp` for the JetBrains backend)
 4. Run `:AndroidInfo` to check SDK and project configuration
 
 **Optional Features:**

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Complete LazyVim configuration with:
   - SDK detection and statusline indicators
   - Markdown with live preview
 - **Languages:** Kotlin, Java, XML, Markdown, TOML, Groovy (Gradle)
-- **Note:** kotlin-language-server (fwcd) supports Kotlin ≤ 2.2.x. For Kotlin 2.3.0+, consider switching to the official [Kotlin/kotlin-lsp](https://github.com/Kotlin/kotlin-lsp).
+- **Kotlin LSP:** Dual LSP support — defaults to the community `kotlin-language-server` (fwcd). For full IntelliJ-level indexing (Kotlin 2.3.0+), switch to the official JetBrains backend with `KOTLIN_LSP=jetbrains`. The JetBrains server auto-cleans up stale RocksDB locks on shutdown to prevent "LOCK: Resource temporarily unavailable" errors.
 
 ### AI Assistant
 - Opencode configuration with specialized agents and plugins
@@ -53,7 +53,6 @@ Complete LazyVim configuration with:
 - **Nerd-fonts terminal**: [Alacritty](https://alacritty.org/) or [Ghostty](https://ghostty.org/)
 
 ### Optional (for AI & Development)
-- **RTK**: `brew install rtk` (reduces LLM token consumption by 60-90%)
 - **Node.js & npm**: `brew install node` (for Markdown preview in nvim)
 
 ### Optional (for Android Development)
@@ -84,7 +83,7 @@ mv ~/.config/nvim{,.bak.$(date +%Y%m%d)} 2>/dev/null || true
 mv ~/.config/opencode{,.bak.$(date +%Y%m%d)} 2>/dev/null || true
 
 # 4. Install dependencies
-brew install neovim thefuck fzf fd rtk
+brew install neovim thefuck fzf fd
 
 # 5. Clone this repo and set up configs
 git clone https://github.com/candradesm/zsh-config ~/.config-temp
@@ -136,7 +135,6 @@ This repo includes a pre-configured [Opencode](https://opencode.ai/) setup with:
 - **TUI Plugins:** Copilot usage sidebar (quota + session tracking), jungle-mode indicator
 - **Server Plugins:** Desktop notifications, jungle-mode persona injection
 - **Configuration:** Ready-to-use settings for AI-assisted development
-- **RTK (Rust Token Killer):** CLI proxy that reduces LLM token consumption by 60-90% on common dev commands. Install via `brew install rtk` and run `rtk init -g --opencode`
 
 See [.config/opencode/AGENTS.md](.config/opencode/AGENTS.md) for agent definitions.
 See [.config/opencode/README.md](.config/opencode/README.md) for plugins, skills, and full documentation.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Complete LazyVim configuration with:
 ### Optional (for Android Development)
 - **Java JDK 21+**: `brew install openjdk` (or from [Adoptium](https://adoptium.net/))
 - **Android SDK with ADB**: Install via Android Studio or `brew install android-platform-tools`
+- **JetBrains kotlin-lsp** (opt-in): `brew install JetBrains/utils/kotlin-lsp` (for full IntelliJ-level indexing; see Kotlin LSP section)
 
 ## Installation
 


### PR DESCRIPTION
## 📋 Changelist Summary
Added dual Kotlin LSP support to Neovim config, allowing toggling between fwcd/kotlin-language-server (default) and JetBrains kotlin-lsp (opt-in) via `KOTLIN_LSP=jetbrains`.

## 💬 Description
- **kotlin.lua**: Dual LSP config with `use_jetbrains` toggle — disables fwcd via `enabled = false` when JetBrains active, adds kotlin.nvim plugin for inlay hints & code actions, filetype detection, LspAttach notification, Gradle/Android init
- **android.lua**: Added Kotlin LSP statusline indicator alongside existing Gradle indicator (both in the same lualine section to avoid merge issues with `optional = true` specs)
- **README.md**: Documented the dual LSP setup, toggle usage, and visual indicators

## ℹ️ Extra info
Toggle via `KOTLIN_LSP=jetbrains` env var or `vim.g.kotlin_lsp = "jetbrains"`. The statusline shows "Kotlin-LSP (JetBrains)" in orange when JetBrains server is active, "Kotlin-LSP" in blue for default fwcd.